### PR TITLE
Bugfix-QSimpleTableClosure to Callable

### DIFF
--- a/includes/base_controls/QSimpleTableColumn.class.php
+++ b/includes/base_controls/QSimpleTableColumn.class.php
@@ -691,11 +691,8 @@
 		 *
 		 * @throws InvalidArgumentException
 		 */
-		public function __construct($strName, $objCallable, $mixParams = null) {
+		public function __construct($strName, callable $objCallable, $mixParams = null) {
 			parent::__construct($strName);
-			if (!is_callable($objCallable)) {
-				throw new InvalidArgumentException('Must be callable.');
-			}
 			if ($objCallable instanceof Closure) {
 				throw new InvalidArgumentException('Cannot be a Closure.');
 			}

--- a/includes/codegen/QMetaEditDlg.class.php
+++ b/includes/codegen/QMetaEditDlg.class.php
@@ -66,7 +66,7 @@ class QMetaEditDlg extends QDialog {
 		$this->dtgGeneralOptions->ShowHeader = false;
 		$this->dtgGeneralOptions->Name = "Definition Options";
 		$this->dtgGeneralOptions->CreatePropertyColumn('Attribute', 'Name');
-		$col = $this->dtgGeneralOptions->AddColumn (new QSimpleTableClosureColumn('Attribute', array ($this, 'dtg_ValueRender'), $this->dtgGeneralOptions));
+		$col = $this->dtgGeneralOptions->AddColumn (new QSimpleTableCallableColumn('Attribute', array ($this, 'dtg_ValueRender'), $this->dtgGeneralOptions));
 		$col->HtmlEntities = false;
 		$this->dtgGeneralOptions->SetDataBinder('dtgGeneralOptions_Bind', $this);
 
@@ -115,7 +115,7 @@ class QMetaEditDlg extends QDialog {
 			$dtg = new QSimpleTable($panel);
 			$dtg->ShowHeader = false;
 			$dtg->CreatePropertyColumn('Attribute', 'Name');
-			$col = $dtg->AddColumn (new QSimpleTableClosureColumn('Attribute', array ($this, 'dtg_ValueRender'), $dtg));
+			$col = $dtg->AddColumn (new QSimpleTableCallableColumn('Attribute', array ($this, 'dtg_ValueRender'), $dtg));
 			$col->HtmlEntities = false;
 			$dtg->SetDataBinder('dtgControlBind', $this);
 			$dtg->Name = $tabName; // holder for category


### PR DESCRIPTION
Since we cannot store closures in the form state, I am changing the name and type hint for this column.