### PR TITLE
bugfix/feature-QTimer

### DIFF
--- a/includes/codegen/QCodeGenBase.class.php
+++ b/includes/codegen/QCodeGenBase.class.php
@@ -578,7 +578,7 @@
 		}
 
 		/**
-		 * Given a table name, returns a variable name that will be used to reprsent the corresponding model object.
+		 * Given a table name, returns a variable name that will be used to represent the corresponding model object.
 		 * @param string $strTableName
 		 * @return string
 		 */

--- a/includes/error.inc.php
+++ b/includes/error.inc.php
@@ -172,10 +172,18 @@
 	 */
 
 	function QCubedShutdown() {
+		if (defined ('__TIMER_OUT_FILE__')) {
+			$strTimerOutput = QTimer::VarDump(false);
+			if ($strTimerOutput) {
+				file_put_contents(__TIMER_OUT_FILE__, $strTimerOutput . "\n", FILE_APPEND);
+			}
+		}
+
 		$error = error_get_last();
 		if ($error &&
-				is_array ($error) &&
-				(!defined ('QCodeGen::DebugMode') || QCodeGen::DebugMode)){ // if we are codegenning, only error if we are in debug mode. Prevents chmod error.
+			is_array ($error) &&
+			(!defined ('QCodeGen::DebugMode') || QCodeGen::DebugMode)) { // if we are codegenning, only error if we are in debug mode. Prevents chmod error.
+
 			QCodoHandleError (
 				$error['type'],
 				$error['message'],

--- a/includes/framework/QTimer.class.php
+++ b/includes/framework/QTimer.class.php
@@ -204,10 +204,10 @@ class QTimer {
 	public static function VarDump($blnDisplayOutput = true) {
 		$strToReturn = '';
 		foreach (self::$objTimerArray as $objTimer) {
-			$strToReturn .= $objTimer->__toString() . "<br>";
+			$strToReturn .= $objTimer->__toString() . "\n";
 		}
 		if ($blnDisplayOutput) {
-			echo $strToReturn;
+			echo nl2br($strToReturn);
 		} else {
 			return $strToReturn;
 		}

--- a/install/project/includes/configuration/configuration.inc.php.sample
+++ b/install/project/includes/configuration/configuration.inc.php.sample
@@ -419,7 +419,8 @@ if (!defined('SERVER_INSTANCE')) {
 			define ('__TEMPLATES_PATH_PLUGIN__', '');	// if using a plugin template, path to that template
 			define ('__TEMPLATES_PATH_PROJECT__', __QCUBED__ . '/codegen/templates/');	// path to the core base templates
 
-
+			/** Uncomment if you are using QTimer to do performance testing. Will automatically output the results of your timers to the file. */
+			//define ('__TIMER_OUT_FILE__', __TMP__ . '/timers.txt');
 		break;
 	}
 }


### PR DESCRIPTION
Fix to timer output so that returned value does not have html.
Fixes to error to avoid problem when error logging does not return complete info.
Also implemented automatic QTimer dumping at the end of execution.