### PR TITLE
bugfix-CodegenErrors

### DIFF
--- a/includes/codegen/templates/db_orm/meta_control/refresh_methods.tpl.php
+++ b/includes/codegen/templates/db_orm/meta_control/refresh_methods.tpl.php
@@ -82,10 +82,12 @@
 		 public function Load(<?= implode (',', $aStrs) ?>, $objClauses = null) {
 			if (<?php foreach ($objTable->PrimaryKeyColumnArray as $objColumn) { ?>strlen($<?= $objColumn->VariableName  ?>) && <?php } ?><?php GO_BACK(4); ?>) {
 				$this-><?= $objCodeGen->ModelVariableName($objTable->Name); ?> = <?= $objTable->ClassName ?>::Load(<?php foreach ($objTable->PrimaryKeyColumnArray as $objColumn) { ?>$<?= $objColumn->VariableName ?>, <?php } ?><?php GO_BACK(2); ?>, $objClauses);
+				$this->strTitleVerb = QApplication::Translate('Edit');
 				$this->blnEditMode = true;
 			}
 			else {
 				$this-><?= $objCodeGen->ModelVariableName($objTable->Name); ?> = new <?= $objTable->ClassName ?>();
+				$this->strTitleVerb = QApplication::Translate('Create');
 				$this->blnEditMode = false;
 			}
 			$this->Refresh ();

--- a/includes/framework/QBaseClass.class.php
+++ b/includes/framework/QBaseClass.class.php
@@ -40,6 +40,13 @@
 			throw new QUndefinedPropertyException("SET", $objReflection->getName(), $strName);
 		}
 
+		public function __call($strName, $arguments)
+		{
+			$objReflection = new ReflectionClass($this);
+			throw new QUndefinedMethodException($objReflection->getName(), $strName);
+		}
+
+
 		/**
 		 * This allows you to set any properties, given by a name-value pair list
 		 * in mixOverrideArray.

--- a/includes/framework/QExceptions.class.php
+++ b/includes/framework/QExceptions.class.php
@@ -67,7 +67,9 @@
 		 * at the very least the Caller of the most immediate function, which is
 		 * 1 up the call stack, is responsible.  So therefore, by default, intOffset
 		 * is set to 1.
+		 * 
 		 * It is rare for intOffset to be set to an integer other than 1.
+		 *
 		 * Normally, the Offset would be altered by calls to IncrementOffset
 		 * at every step the CallerException is caught/rethrown up the call stack.
 		 *
@@ -167,6 +169,15 @@
 		 */
 		public function __construct($strType, $strClass, $strProperty) {
 			parent::__construct(sprintf("Undefined %s property or variable in '%s' class: %s", $strType, $strClass, $strProperty), 2);
+		}
+	}
+
+	/**
+	 * Thrown when we try to call an undefined method. Helpful for codegen.
+	 */
+	class QUndefinedMethodException extends QCallerException {
+		public function __construct($strClass, $strMethod) {
+			parent::__construct(sprintf("Undefined method in '%s' class: %s", $strClass, $strMethod), 2);
 		}
 	}
 


### PR DESCRIPTION
Fixes a problem where a template that calls a non-existant method would cause codegen to return a blank page, rather than an error code.

Also restored title on load of metacontrol.