### PR TITLE
bugfix-ValidationErrorRedraw

### DIFF
--- a/includes/base_controls/QCheckBox.class.php
+++ b/includes/base_controls/QCheckBox.class.php
@@ -169,14 +169,12 @@
 			if ($this->blnRequired) {
 				if (!$this->blnChecked) {
 					if ($this->strName)
-						$this->strValidationError = QApplication::Translate($this->strName) . ' ' . QApplication::Translate('is required');
+						$this->ValidationError = QApplication::Translate($this->strName) . ' ' . QApplication::Translate('is required');
 					else
-						$this->strValidationError = QApplication::Translate('Required');
+						$this->ValidationError = QApplication::Translate('Required');
 					return false;
 				}
 			}
-
-			$this->strValidationError = null;
 			return true;
 		}
 
@@ -288,7 +286,7 @@
 		/* === Codegen Helpers, used during the Codegen process only. === */
 
 		/**
-		 * /**
+		 *
 		 * Returns the variable name for a control of this type during code generation process
 		 *
 		 * @param string $strPropName Property name for which the control to be generated is being generated
@@ -364,11 +362,10 @@ TMPL;
 		/**
 		 * Generate code to reload data from the MetaControl into this control, or load it for the first time
 		 *
-		 * @param QCodeGen                                       $objCodeGen
-		 * @param QTable                                         $objTable
+		 * @param QCodeGen $objCodeGen
+		 * @param QTable $objTable
 		 * @param QColumn|QReverseReference|QManyToManyReference $objColumn
 		 *
-		 * @return string
 		 * @return string
 		 */
 		public static function Codegen_MetaRefresh(QCodeGen $objCodeGen, QTable $objTable, QColumn $objColumn) {
@@ -399,4 +396,3 @@ TMPL;
 			return $strRet;
 		}
 	}
-?>

--- a/includes/base_controls/QCheckBoxList.class.php
+++ b/includes/base_controls/QCheckBoxList.class.php
@@ -272,12 +272,10 @@
 		public function Validate() {
 			if ($this->blnRequired) {
 				if ($this->SelectedIndex == -1) {
-					$this->strValidationError = QApplication::Translate($this->strName) . ' ' . QApplication::Translate('is required');
+					$this->ValidationError = QApplication::Translate($this->strName) . ' ' . QApplication::Translate('is required');
 					return false;
 				}
 			}
-
-			$this->strValidationError = null;
 			return true;
 		}
 

--- a/includes/base_controls/QControlBase.class.php
+++ b/includes/base_controls/QControlBase.class.php
@@ -84,9 +84,9 @@
 	 * @property string $PreferredRenderMethod carries the name of the function, which were initially used for rendering
 	 * @property boolean $Required specifies whether or not this is required (will cause a validation error if the form is trying to be validated and this control is left blank)
 	 * @property-read string $StyleSheets
-	 * @property-read string $ValidationError is the string that contains the validation error (if applicable) or will be blank if (1) the form did not undergo its validation routine or (2) this control had no error
+	 * @property string $ValidationError is the string that contains the validation error (if applicable) or will be blank if (1) the form did not undergo its validation routine or (2) this control had no error
 	 * @property boolean $Visible specifies whether or not the control should be rendered in the page.  This is in contrast to Display, which will just hide the control via CSS styling.
-	 * @property string $Warning is warning text (looks like an error, but it can be user defined) that will be shown next to the control's name label {@link QControl::RenderWithName}
+	 * @property string $Warning is warning text that will be shown next to the control's name label {@link QControl::RenderWithName}
 	 * @property boolean $UseWrapper defaults to true
 	 * @property-read boolean $WrapperModified
 	 * @property string $WrapperCssClass
@@ -1942,6 +1942,16 @@
 				case "Warning":
 					try {
 						$this->strWarning = QType::Cast($mixValue, QType::String);
+						$this->MarkAsModified(); // always modify, since it will get reset on subsequent drawing
+						break;
+					} catch (QInvalidCastException $objExc) {
+						$objExc->IncrementOffset();
+						throw $objExc;
+					}
+
+				case "ValidationError":
+					try {
+						$this->strValidationError = QType::Cast($mixValue, QType::String);
 						$this->MarkAsModified(); // always modify, since it will get reset on subsequent drawing
 						break;
 					} catch (QInvalidCastException $objExc) {

--- a/includes/base_controls/QCsvTextBox.class.php
+++ b/includes/base_controls/QCsvTextBox.class.php
@@ -51,13 +51,13 @@
 
 				if ($this->intMinItemCount !== null &&
 						count ($a) < $this->intMinItemCount) {
-					$this->strValidationError = sprintf($this->strLabelForTooShort, $this->intMinItemCount);
+					$this->ValidationError = sprintf($this->strLabelForTooShort, $this->intMinItemCount);
 					return false;
 				}
 
 				if ($this->intMaxItemCount !== null &&
 					count ($a) > $this->intMaxItemCount) {
-					$this->strValidationError = sprintf($this->strLabelForTooLong, $this->intMaxItemCount);
+					$this->ValidationError = sprintf($this->strLabelForTooLong, $this->intMaxItemCount);
 					return false;
 				}
 

--- a/includes/base_controls/QDateTimePicker.class.php
+++ b/includes/base_controls/QDateTimePicker.class.php
@@ -323,9 +323,9 @@
 
 				if ($blnIsNull) {
 					if ($this->strName)
-						$this->strValidationError = sprintf(QApplication::Translate('%s is required'), $this->strName);
+						$this->ValidationError = sprintf(QApplication::Translate('%s is required'), $this->strName);
 					else
-						$this->strValidationError = QApplication::Translate('Required');
+						$this->ValidationError = QApplication::Translate('Required');
 					return false;
 				}
 			} else {
@@ -334,12 +334,11 @@
 					($this->strDateTimePickerType == QDateTimePickerType::DateTimeSeconds )) &&
 					($this->intSelectedDay || $this->intSelectedMonth || $this->intSelectedYear) &&
 					($this->dttDateTime->IsDateNull())) {
-					$this->strValidationError = QApplication::Translate('Invalid Date');
+					$this->ValidationError = QApplication::Translate('Invalid Date');
 					return false;
 				}
 			}
 
-			$this->strValidationError = '';
 			return true;
 		}
 

--- a/includes/base_controls/QDateTimeTextBox.class.php
+++ b/includes/base_controls/QDateTimeTextBox.class.php
@@ -86,7 +86,7 @@
 					$dttTest = QDateTimeTextBox::ParseForDateTimeValue($this->strText);
 
 					if (!$dttTest) {
-						$this->strValidationError = $this->strLabelForInvalid;
+						$this->ValidationError = $this->strLabelForInvalid;
 						return false;
 					}
 
@@ -100,7 +100,7 @@
 						}
 
 						if ($dttTest->IsEarlierThan($dttToCompare)) {
-							$this->strValidationError = 'Date cannot be ' . $strError;
+							$this->ValidationError = 'Date cannot be ' . $strError;
 							return false;
 						}
 					}
@@ -115,7 +115,7 @@
 						}
 
 						if ($dttTest->IsLaterThan($dttToCompare)) {
-							$this->strValidationError = 'Date cannot be ' . $strError;
+							$this->ValidationError = 'Date cannot be ' . $strError;
 							return false;
 						}
 					}
@@ -123,7 +123,6 @@
 			} else
 				return false;
 
-			$this->strValidationError = '';
 			return true;
 		}
 

--- a/includes/base_controls/QDatepickerBoxBase.class.php
+++ b/includes/base_controls/QDatepickerBoxBase.class.php
@@ -52,25 +52,23 @@
 			if ($this->strText != '') {
 				$dttDateTime = new QDateTime($this->strText, null, QDateTime::DateOnlyType);
 				if ($dttDateTime->IsDateNull()) {
-					$this->strValidationError = QApplication::Translate("Invalid date");
+					$this->ValidationError = QApplication::Translate("Invalid date");
 					return false;
 				}
 				if (!is_null($this->Minimum)) {
 					if ($dttDateTime->IsEarlierThan($this->Minimum)) {
-						$this->strValidationError = QApplication::Translate("Date is earlier than minimum allowed");
+						$this->ValidationError = QApplication::Translate("Date is earlier than minimum allowed");
 						return false;
 					}
 				}
 
 				if (!is_null($this->Maximum)) {
 					if ($dttDateTime->IsLaterThan($this->Maximum)) {
-						$this->strValidationError = QApplication::Translate("Date is later than maximum allowed");
+						$this->ValidationError = QApplication::Translate("Date is later than maximum allowed");
 						return false;
 					}
 				}
 			}
-
-			$this->strValidationError = '';
 			return true;
 		}
 

--- a/includes/base_controls/QFileAssetBase.class.php
+++ b/includes/base_controls/QFileAssetBase.class.php
@@ -91,9 +91,9 @@
 				if ($this->blnRequired && !$this->strFile) {
 					$blnToReturn = false;
 					if ($this->strName)
-						$this->strValidationError = $this->strName . QApplication::Translate(' is required');
+						$this->ValidationError = $this->strName . QApplication::Translate(' is required');
 					else
-						$this->strValidationError = $this->strName . QApplication::Translate('Required');
+						$this->ValidationError = $this->strName . QApplication::Translate('Required');
 				}
 			}
 

--- a/includes/base_controls/QFileControl.class.php
+++ b/includes/base_controls/QFileControl.class.php
@@ -74,12 +74,11 @@
 		 * @return bool
 		 */
 		public function Validate() {
-			$this->strValidationError = "";
 			if ($this->blnRequired) {
 				if (strlen($this->strFileName) > 0)
 					return true;
 				else {
-					$this->strValidationError = QApplication::Translate($this->strName) . ' ' . QApplication::Translate('is required');
+					$this->ValidationError = QApplication::Translate($this->strName) . ' ' . QApplication::Translate('is required');
 					return false;
 				}
 			} else

--- a/includes/base_controls/QFormBase.class.php
+++ b/includes/base_controls/QFormBase.class.php
@@ -252,18 +252,23 @@
 		protected function Form_PreRender() {}
 
 		/**
-		 * The 'Default' Form_Validate method. This method in any class derived from QForm (pages created by QCubed).
-		 * This method runs everytime an action is triggered (the form is submitted)
-		 * The overriding function in the derived class is supposed to use this function to specify
-		 * the conditions which when fulfilled represent a satisfactory input from the user (and would return true).
-		 * If the required conditions (e.g. a 'Required' input was left blank) is not met, the function is
-		 * supposed to return false.
+		 * The Form_Validate method.
 		 *
-		 * If this function (the overridden function in the child class) returns false then the action is
-		 * not triggerred and nothing happens (the script ends silently)
-		 * @return bool
+		 * Before we get here, all the controls will first be validated. Override this method to do
+		 * additional form level validation, and any form level actions needed as part of the validation process,
+		 * like displaying an error message.
+		 *
+		 * This is the last thing called in the validation process, and will always be called if
+		 * validation is requested, even if prior controls caused a validation error. Return false to prevent
+		 * validation and cancel the current action.
+		 *
+		 * $blnValid will contain the result of control validation. If it is false, you know that validation will
+		 * fail, regardless of what you return from the function.
+		 *
+		 * @param bool 		$blnValid	The current state of the validation.
+		 * @return bool 	Return false to prevent validation.
 		 */
-		protected function Form_Validate() {return true;}
+		protected function Form_Validate($blnValid) {return true;}
 
 		/**
 		 * This function is meant to be overriden by child class and is called when the Form exits
@@ -1225,7 +1230,7 @@
 
 						// Run Form-Specific Validation (if any)
 						if ($mixCausesValidation && !($mixCausesValidation instanceof QDialog)) {
-							if (!$this->Form_Validate()) {
+							if (!$this->Form_Validate($blnValid)) {
 								$blnValid = false;
 							}
 						}
@@ -1309,8 +1314,9 @@
 			foreach ($this->GetAllControls() as $objControl) {
 				// Include any StyleSheets?  The control would have a
 				// comma-delimited list of stylesheet files to include (if applicable)
-				if ($strScriptArray = $this->ProcessStyleSheetList($objControl->StyleSheets))
+				if ($strScriptArray = $this->ProcessStyleSheetList($objControl->StyleSheets)) {
 					$strStyleSheetArray = array_merge($strStyleSheetArray, $strScriptArray);
+				}
 			}
 
 			// In order to make ui-themes workable, move the jquery.css to the end of list.

--- a/includes/base_controls/QListBoxBase.class.php
+++ b/includes/base_controls/QListBoxBase.class.php
@@ -196,22 +196,22 @@
 			if ($this->blnRequired) {
 				if ($this->SelectedIndex == -1) {
 					if ($this->strName)
-						$this->strValidationError = sprintf($this->strLabelForRequired, $this->strName);
+						$this->ValidationError = sprintf($this->strLabelForRequired, $this->strName);
 					else
-						$this->strValidationError = $this->strLabelForRequiredUnnamed;
+						$this->ValidationError = $this->strLabelForRequiredUnnamed;
 					return false;
 				}
 
 				if (($this->SelectedIndex == 0) && (strlen($this->SelectedValue) == 0)) {
 					if ($this->strName)
-						$this->strValidationError = sprintf($this->strLabelForRequired, $this->strName);
+						$this->ValidationError = sprintf($this->strLabelForRequired, $this->strName);
 					else
-						$this->strValidationError = $this->strLabelForRequiredUnnamed;
+						$this->ValidationError = $this->strLabelForRequiredUnnamed;
 					return false;
 				}
 			}
 
-			$this->strValidationError = null;
+			$this->ValidationError = null;
 			return true;
 		}
 

--- a/includes/base_controls/QNumericTextBox.class.php
+++ b/includes/base_controls/QNumericTextBox.class.php
@@ -70,13 +70,13 @@
 					try {
 						$this->strText = QType::Cast($this->strText, $this->strDataType);
 					} catch (QInvalidCastException $objExc) {
-						$this->strValidationError = $this->strLabelForInvalid;
+						$this->ValidationError = $this->strLabelForInvalid;
 						$this->MarkAsModified();
 						return false;
 					}
 
 					if (!is_numeric($this->strText)) {
-						$this->strValidationError = $this->strLabelForInvalid;
+						$this->ValidationError = $this->strLabelForInvalid;
 						$this->MarkAsModified();
 						return false;
 					}
@@ -86,7 +86,7 @@
 
 						if ($newVal != $this->strText) {
 							if ($this->strLabelForNotStepAligned) {
-								$this->strValidationError = sprintf($this->strLabelForNotStepAligned, $this->mixStep);
+								$this->ValidationError = sprintf($this->strLabelForNotStepAligned, $this->mixStep);
 								$this->MarkAsModified();
 								return false;
 							}
@@ -96,13 +96,13 @@
 					}
 
 					if ((!is_null($this->mixMinimum)) && ($this->strText < $this->mixMinimum)) {
-						$this->strValidationError = sprintf($this->strLabelForGreater, $this->mixMinimum);
+						$this->ValidationError = sprintf($this->strLabelForGreater, $this->mixMinimum);
 						$this->MarkAsModified();
 						return false;
 					}
 
 					if ((!is_null($this->mixMaximum)) && ($this->strText > $this->mixMaximum)) {
-						$this->strValidationError = sprintf($this->strLabelForLess, $this->mixMaximum);
+						$this->ValidationError = sprintf($this->strLabelForLess, $this->mixMaximum);
 						$this->MarkAsModified();
 						return false;
 					}
@@ -110,7 +110,6 @@
 			} else
 				return false;
 
-			$this->strValidationError = "";
 			return true;
 		}
 

--- a/includes/base_controls/QRadioButtonList.class.php
+++ b/includes/base_controls/QRadioButtonList.class.php
@@ -263,12 +263,11 @@
 		public function Validate() {
 			if ($this->blnRequired) {
 				if ($this->SelectedIndex == -1) {
-					$this->strValidationError = sprintf(QApplication::Translate('%s is required'), $this->strName);
+					$this->ValidationError = sprintf(QApplication::Translate('%s is required'), $this->strName);
 					return false;
 				}
 			}
 
-			$this->strValidationError = null;
 			return true;
 		}
 

--- a/includes/base_controls/QTextBoxBase.class.php
+++ b/includes/base_controls/QTextBoxBase.class.php
@@ -318,8 +318,6 @@
 		 * @return bool whether or not the control is valid
 		 */
 		public function Validate() {
-			$this->strValidationError = "";
-
 			// Get the Text string
 			if ($this->blnValidateTrimmed)
 				$strText = trim($this->strText);
@@ -329,9 +327,9 @@
 			if ($this->blnRequired) {
 				if (mb_strlen($strText, QApplication::$EncodingType) == 0) {
 					if ($this->strName)
-						$this->strValidationError = sprintf($this->strLabelForRequired, $this->strName);
+						$this->ValidationError = sprintf($this->strLabelForRequired, $this->strName);
 					else
-						$this->strValidationError = $this->strLabelForRequiredUnnamed;
+						$this->ValidationError = $this->strLabelForRequiredUnnamed;
 					return false;
 				}
 			}
@@ -340,9 +338,9 @@
 			if ($this->intMinLength > 0) {
 				if (mb_strlen($strText, QApplication::$EncodingType) < $this->intMinLength) {
 					if ($this->strName)
-						$this->strValidationError = sprintf($this->strLabelForTooShort, $this->strName, $this->intMinLength);
+						$this->ValidationError = sprintf($this->strLabelForTooShort, $this->strName, $this->intMinLength);
 					else
-						$this->strValidationError = sprintf($this->strLabelForTooShortUnnamed, $this->intMinLength);
+						$this->ValidationError = sprintf($this->strLabelForTooShortUnnamed, $this->intMinLength);
 					return false;
 				}
 			}
@@ -351,9 +349,9 @@
 			if ($this->intMaxLength > 0) {
 				if (mb_strlen($strText, QApplication::$EncodingType) > $this->intMaxLength) {
 					if ($this->strName)
-						$this->strValidationError = sprintf($this->strLabelForTooLong, $this->strName, $this->intMaxLength);
+						$this->ValidationError = sprintf($this->strLabelForTooLong, $this->strName, $this->intMaxLength);
 					else
-						$this->strValidationError = sprintf($this->strLabelForTooLongUnnamed, $this->intMaxLength);
+						$this->ValidationError = sprintf($this->strLabelForTooLongUnnamed, $this->intMaxLength);
 					return false;
 				}
 			}
@@ -361,7 +359,7 @@
 			// Check against PHP validation
 			if ($this->intValidateFilter && $this->strText) { 
 				if (!filter_var($this->strText, $this->intValidateFilter, $this->mixValidateFilterOptions)) {
-					$this->strValidationError = $this->strLabelForInvalid;
+					$this->ValidationError = $this->strLabelForInvalid;
 					return false;
 				}
 			}

--- a/includes/base_controls/QTreeNav.class.php
+++ b/includes/base_controls/QTreeNav.class.php
@@ -213,15 +213,13 @@
 		}
 
 		public function Validate() {
-			$this->strValidationError = "";
-
 			// Check for Required
 			if ($this->blnRequired && $this->SelectedItem === null)
 			{
 				if ($this->strName)
-					$this->strValidationError = sprintf($this->strLabelForRequired, $this->strName);
+					$this->ValidationError = sprintf($this->strLabelForRequired, $this->strName);
 				else
-					$this->strValidationError = $this->strLabelForRequiredUnnamed;
+					$this->ValidationError = $this->strLabelForRequiredUnnamed;
 				return false;
 			}
 

--- a/install/project/includes/controls/QImageFileAsset.class.php
+++ b/install/project/includes/controls/QImageFileAsset.class.php
@@ -44,22 +44,22 @@
 
 					if (isset($this->intMinWidth) AND $this->intMinWidth > $width) {
 						$blnToReturn = false;
-						$this->strValidationError = $this->strName . QApplication::Translate(' is too short the min width is ') . $this->intMinWidth;
+						$this->ValidationError = $this->strName . QApplication::Translate(' is too short the min width is ') . $this->intMinWidth;
 					}
 
 					if (isset($this->intMaxWidth) AND $this->intMaxWidth < $width) {
 						$blnToReturn = false;
-						$this->strValidationError = $this->strName . QApplication::Translate(' is too big the max width is ') . $this->intMaxWidth;
+						$this->ValidationError = $this->strName . QApplication::Translate(' is too big the max width is ') . $this->intMaxWidth;
 					}
 
 					if (isset($this->intMinHeight) AND $this->intMinHeight > $height) {
 						$blnToReturn = false;
-						$this->strValidationError = $this->strName . QApplication::Translate(' is too short the min height is ') . $this->intMinHeight;
+						$this->ValidationError = $this->strName . QApplication::Translate(' is too short the min height is ') . $this->intMinHeight;
 					}
 
 					if (isset($this->intMaxHeight) AND $this->intMaxHeight < $height) {
 						$blnToReturn = false;
-						$this->strValidationError = $this->strName . QApplication::Translate(' is too big the max height is ') . $this->intMaxHeight;
+						$this->ValidationError = $this->strName . QApplication::Translate(' is too big the max height is ') . $this->intMaxHeight;
 					}
 				}
 			}


### PR DESCRIPTION
Changing the setting of the validation error to the attribute. Fixing a problem where setting the validation error from within controls by just setting the text did not cause a redraw.Also, make a distinction between Errors and Warnings for CSS frameworks.