### PR TITLE
feature-Refactor of list items

### DIFF
--- a/assets/php/tests/ui_basic.php
+++ b/assets/php/tests/ui_basic.php
@@ -99,6 +99,7 @@
 			$this->lstSelect->Warning = 'Value = ' . $this->lstSelect->SelectedValue;
 			$this->lstSelect2->Warning = 'Values = ' . implode (',', $this->lstSelect2->SelectedValues);
 			$this->lstCheck->Warning = 'Values = ' . implode (',', $this->lstCheck->SelectedValues);
+			$this->lstCheck2->Warning = 'Values = ' . implode (',', $this->lstCheck2->SelectedValues);
 			$this->lstRadio->Warning = 'Value = ' . $this->lstRadio->SelectedValue;
 			$this->rdoRadio1->Warning = 'Value = ' . $this->rdoRadio1->Checked;
 			$this->rdoRadio2->Warning = 'Value = ' . $this->rdoRadio2->Checked;

--- a/assets/php/tests/ui_hlist.php
+++ b/assets/php/tests/ui_hlist.php
@@ -1,0 +1,51 @@
+<?php
+    require_once('../qcubed.inc.php');
+    
+	class SelectForm extends QForm {
+		protected $list1;
+
+		protected $btnServer;
+		protected $btnAjax;
+
+		protected function Form_Create() {
+			$this->list1 = new QHtmlList($this);
+			$this->list1->Name = 'List';
+
+			$a = [new QListItem ('A', 1),
+				new QListItem ('B', 2),
+				new QListItem ('C', 3),
+				new QListItem ('D', 4)
+			];
+
+			$this->list1->AddItems($a);
+			$this->list1->SetDataBinder([$this, 'DataBind']);
+
+			$this->btnServer = new QButton ($this);
+			$this->btnServer->Text = 'Server Submit';
+			$this->btnServer->AddAction(new QClickEvent(), new QServerAction('submit_click'));
+
+			$this->btnAjax = new QButton ($this);
+			$this->btnAjax->Text = 'Ajax Submit';
+			$this->btnAjax->AddAction(new QClickEvent(), new QAjaxAction('submit_click'));
+		}
+
+		protected function submit_click($strFormId, $strControlId, $strParameter) {
+		}
+
+		public function DataBind() {
+			$a = [new QListItem ('A', 1),
+				new QListItem ('B', 2),
+				new QListItem ('C', 3),
+				new QListItem ('D', 4)
+			];
+
+			$a[0]->AddItems(['aa'=>0, 'ab'=>2, 'ac'=>3]);
+			$a[1]->AddItems(['ba'=>0, 'bb'=>1]);
+
+			$this->list1->RemoveAllItems();
+			$this->list1->AddItems($a);
+		}
+		
+	}
+	SelectForm::Run('SelectForm');
+?>

--- a/assets/php/tests/ui_hlist.tpl.php
+++ b/assets/php/tests/ui_hlist.tpl.php
@@ -1,0 +1,7 @@
+<?php require('../../../../../../project/includes/configuration/header.inc.php'); ?>
+<?php $this->RenderBegin(); ?>
+<?php $this->list1->RenderWithName(); ?>
+<?php $this->btnServer->Render(); ?>
+<?php $this->btnAjax->Render(); ?>
+<?php $this->RenderEnd(); ?>
+<?php require('../../../../../../project/includes/configuration/footer.inc.php'); ?>

--- a/includes/base_controls/QAutocompleteBase.class.php
+++ b/includes/base_controls/QAutocompleteBase.class.php
@@ -225,6 +225,7 @@
 					break;
 					
 				case "SelectedValue":	// mirror list control
+				case "Value":
 				case 'SelectedId':
 					// Set this at creation time to initialize the selected id. 
 					// This is also set by the javascript above to keep track of subsequent selections made by the user.
@@ -280,6 +281,7 @@
 		public function __get($strName) {
 			switch ($strName) {
 				case "SelectedValue":	// mirror list control
+				case "Value": // most common situation
 				case 'SelectedId': return $this->strSelectedId;
 
 				default: 

--- a/includes/base_controls/QCheckBoxList.class.php
+++ b/includes/base_controls/QCheckBoxList.class.php
@@ -70,24 +70,15 @@
 		public function ParsePostData() {
 			if (QApplication::$RequestMode == QRequestMode::Ajax) {
 				// Ajax will only send information about controls that are on the screen, so we know they are rendered
-				for ($intIndex = 0; $intIndex < count($this->objItemsArray); $intIndex++) {
-					if (!empty($_POST[$this->strControlId][$intIndex]))
-						$this->objItemsArray[$intIndex]->Selected = true;
-					else
-						$this->objItemsArray[$intIndex]->Selected = false;
-				}
+				$a = array_keys($_POST[$this->strControlId]);
+				$this->SetSelectedItemsByIndex($a, false);
 			}
 			elseif ($this->objForm->IsCheckableControlRendered($this->strControlId)) {
 				if ((array_key_exists($this->strControlId, $_POST)) && (is_array($_POST[$this->strControlId]))) {
-					for ($intIndex = 0; $intIndex < count($this->objItemsArray); $intIndex++) {
-						if (array_key_exists($intIndex, $_POST[$this->strControlId]))
-							$this->objItemsArray[$intIndex]->Selected = true;
-						else
-							$this->objItemsArray[$intIndex]->Selected = false;
-					}
+					$a = array_keys($_POST[$this->strControlId]);
+					$this->SetSelectedItemsByIndex($a, false);
 				} else {
-					for ($intIndex = 0; $intIndex < count($this->objItemsArray); $intIndex++) 
-						$this->objItemsArray[$intIndex]->Selected = false;
+					$this->UnselectAllItems(false);
 				}
 			}
 		}
@@ -119,7 +110,7 @@
 			$objStyles->SetHtmlAttribute('type', 'checkbox');
 			$objStyles->SetHtmlAttribute('name', $this->strControlId . '[' . $intIndex . ']');
 
-			$strIndexedId = $this->strControlId . '_' . $intIndex;
+			$strIndexedId = $objItem->ControlId;
 			$objStyles->SetHtmlAttribute('id', $strIndexedId);
 			if ($strTabIndex) {
 				$objStyles->TabIndex = $strTabIndex;
@@ -155,7 +146,7 @@
 		}
 
 		protected function GetControlHtml() {
-			if ((!$this->objItemsArray) || (count($this->objItemsArray) == 0))
+			if ((!$this->objListItemArray) || (count($this->objListItemArray) == 0))
 				return "";
 
 			/* Deprecated. Use Margin and Padding on the ItemStyle attribute.
@@ -225,7 +216,7 @@
 								+ min(($this->ItemCount % $this->intRepeatColumns), $intColIndex)
 								+ $intRowIndex;
 
-						$strItemHtml = $this->GetItemHtml($this->objItemsArray[$intIndex], $intIndex, $this->GetHtmlAttribute('tabindex'), $this->blnWrapLabel);
+						$strItemHtml = $this->GetItemHtml($this->objListItemArray[$intIndex], $intIndex, $this->GetHtmlAttribute('tabindex'), $this->blnWrapLabel);
 						$strCellHtml = QHtml::RenderTag ('td', null, $strItemHtml);
 						$strRowHtml .= $strCellHtml;
 					}
@@ -247,7 +238,7 @@
 			$count = $this->ItemCount;
 			$strToReturn = '';
 			for ($intIndex = 0; $intIndex < $count; $intIndex++) {
-				$strToReturn .= $this->GetItemHtml($this->objItemsArray[$intIndex], $intIndex, $this->GetHtmlAttribute('tabindex'), $this->blnWrapLabel) . "\n";
+				$strToReturn .= $this->GetItemHtml($this->objListItemArray[$intIndex], $intIndex, $this->GetHtmlAttribute('tabindex'), $this->blnWrapLabel) . "\n";
 			}
 			$strToReturn = $this->RenderTag('div', ['id'=>$this->strControlId], null, $strToReturn);
 			return $strToReturn;
@@ -261,7 +252,7 @@
 			$count = $this->ItemCount;
 			$strToReturn = '';
 			for ($intIndex = 0; $intIndex < $count; $intIndex++) {
-				$strHtml = $this->GetItemHtml($this->objItemsArray[$intIndex], $intIndex, $this->GetHtmlAttribute('tabindex'), $this->blnWrapLabel);
+				$strHtml = $this->GetItemHtml($this->objListItemArray[$intIndex], $intIndex, $this->GetHtmlAttribute('tabindex'), $this->blnWrapLabel);
 				$strToReturn .= QHtml::RenderTag('div', null, $strHtml);
 			}
 			$strToReturn = $this->RenderTag('div', ['id'=>$this->strControlId], null, $strToReturn);

--- a/includes/base_controls/QHtmlAttributeManagerBase.class.php
+++ b/includes/base_controls/QHtmlAttributeManagerBase.class.php
@@ -66,7 +66,7 @@
  *  converted to dashed notation. Use GetDataAttribute() to retrieve the value of a data attribute.
  * @property boolean $NoWrap sets the CSS white-space  property to nowrap
  * @property boolean $ReadOnly is the "readonly" html attribute (making a textbox "ReadOnly" is  similar to setting the textbox to Enabled
- *  Readonly textboxes are selectedable, and their values get posted. Disabled textboxes are not selectabel and values do not post.
+ *  Readonly textboxes are selectedable, and their values get posted. Disabled textboxes are not selectable and values do not post.
  * @property string $AltText text used for 'alt' attribute in images
  */
 
@@ -393,7 +393,7 @@ class QHtmlAttributeManagerBase extends QBaseClass {
 	/**
 	 * Mark the parent class as modified. The host class must implement this if this functionality is desired.
 	 */
-	protected function MarkAsModified() {}
+	public function MarkAsModified() {}
 
 	/**
 	 * Returns the html for the attributes. Allows the given arrays to override the attributes and styles before

--- a/includes/base_controls/QListItem.class.php
+++ b/includes/base_controls/QListItem.class.php
@@ -5,18 +5,28 @@
 	 */
 
 	/**
-	 * Utilized by the {@link QListControl} class which contains a private array of ListItems.
+	 * Utilized by the {@link QListControl} class which contains a private array of ListItems. Originally these
+	 * represented items in a select list, but now represent items in any kind of control that has repetitive items
+	 * in it. This includes list controls, menus, drop-downs, and hierarchical lists. This is a general purpose container
+	 * for the options in each item. Note that not all the options are used by every control, and we don't do any drawing here.
 	 *
 	 * @package Controls
-	 * @property string         $Name      is what gets displayed
-	 * @property string         $Value     is any text that represents the value of the ListItem (e.g. maybe a DB Id)
+	 * @property string         $Name      Usually what gets displayed. Can be overridden by the Label attribute in certain situations.
+	 * @property string         $Value     is any text that represents the value of the item (e.g. maybe a DB Id)
 	 * @property boolean        $Selected  is a boolean of whether or not this item is selected or not (do only! use during initialization, otherwise this should be set by the {@link QListControl}!)
 	 * @property string         $ItemGroup is the group (if any) in which the Item should be displayed
-	 * @property QListItemStyle $ItemStyle is the QListItemStyle in which the Item should be rendered
-	 * @property string         $Label     is optional text to display in the drop down menu of a QAutocomplete instead of the Name. The Name will still be what gets filled in to the text box.
+	 * @property QListItemStyle $ItemStyle Custom HTML attributes for this particular item.
+	 * @property string         $Text      synonym of Name. Used to store longer text with the item.
+	 * @property string         $Label     is optional text to display instead of the Name for certain controls.
 	 * @property-read boolean   $Empty     true when both $Name and $Value are null, in which case this item will be rendered with an empty value in the list control
+	 * @property string $Anchor If set, the anchor text to print in the href= string when drawing as an anchored item.
+	 * @property string $ControlId If set, the id associated with the item.
+	 * @property string $Id 	Synonym of ControlId.
 	 */
 	class QListItem extends QBaseClass {
+
+		use QListItemManager;
+
 		///////////////////////////
 		// Private Member Variables
 		///////////////////////////
@@ -26,12 +36,19 @@
 		protected $strValue = null;
 		/** @var bool Is the item selected? */
 		protected $blnSelected = false;
-		/** @var null|string Group to which the item belongs */
+		/** @var null|string Group to which the item belongs, if control supports groups. */
 		protected $strItemGroup = null;
-		/** @var QListItemStyle Inline style of the item */
+		/** @var QListItemStyle Custom attributes of the list item */
 		protected $objItemStyle;
-		/** @var string Label text for the item */
+		/** @var string Label text for the item. */
 		protected $strLabel = null;
+		/** @var  string if this has an anchor, what to redirect to. Could be javascript or a page. */
+		protected $strAnchor;
+		/** @var QListItem[] and array of subitems if this is a recursive item.  */
+		protected $objSubItems;
+		/** @var  string the internal id */
+		protected $strControlId;
+
 
 		/////////////////////////
 		// Methods
@@ -43,14 +60,14 @@
 		 * @param string  $strValue     is any text that represents the value of the ListItem (e.g. maybe a DB Id)
 		 * @param boolean $blnSelected  is a boolean of whether or not this item is selected or not (optional)
 		 * @param string  $strItemGroup is the group (if any) in which the Item should be displayed
-		 * @param array   $strOverrideParameters
+		 * @param array|string   $mixOverrideParameters
 		 *                              allows you to override item styles.  It is either a string formatted as Property=Value
 		 *                              or an array of the format array(property => value)
 		 *
 		 * @throws Exception|QCallerException
 		 * @return QListItem
 		 */
-		public function __construct($strName, $strValue, $blnSelected = false, $strItemGroup = null, $strOverrideParameters = null) {
+		public function __construct($strName, $strValue = null, $blnSelected = false, $strItemGroup = null, $mixOverrideParameters = null) {
 			$this->strName = $strName;
 			$this->strValue = $strValue;
 			$this->blnSelected = $blnSelected;
@@ -59,26 +76,17 @@
 			// Override parameters get applied here
 			$strOverrideArray = func_get_args();
 			if (count($strOverrideArray) > 4)	{
-				try {
-					$strOverrideArray = array_reverse($strOverrideArray);
-					array_pop($strOverrideArray);
-					array_pop($strOverrideArray);
-					array_pop($strOverrideArray);
-					array_pop($strOverrideArray);
-					$strOverrideArray = array_reverse($strOverrideArray);
-					$this->objItemStyle = new QListItemStyle();
-					$this->objItemStyle->OverrideAttributes($strOverrideArray);
-				} catch (QCallerException $objExc) {
-					$objExc->IncrementOffset();
-					throw $objExc;
-				}
+				throw new QCallerException ("Please provide either a string, or an array, but not multiple parameters");
+			}
+			if ($mixOverrideParameters) {
+				$this->objItemStyle = new QListItemStyle();
+				$this->objItemStyle->OverrideAttributes($mixOverrideParameters);
 			}
 		}
 
 		/**
 		 * Returns the css style of the list item
-		 * @param bool $blnIncludeCustom [Currently Unused]
-		 * @param bool $blnIncludeAction [Currently Unused]
+		 * @deprecated
 		 *
 		 * @return string
 		 */
@@ -88,11 +96,17 @@
 		}
 
 		/**
-		 * Returns the details of the control as JSON string
+		 * Returns the details of the control as JSON string. This is customized for the JQuery UI autocomplete. If your
+		 * widget requires something else, you will need to subclass and override this.
 		 * @return string
 		 */
 		public function toJsObject() {
-			$a = array('value' => $this->strName, 'id' => $this->strValue);
+			$strControlId = $this->strValue;
+			if (!$strControlId) {
+				$strControlId = $this->strControlId;
+			}
+
+			$a = array('value' => $this->strName, 'id' => $strControlId);
 			if ($this->strLabel) {
 				$a['label'] = $this->strLabel;
 			}
@@ -122,6 +136,18 @@
 				case "ItemStyle": return $this->objItemStyle;
 				case "Label": return $this->strLabel;
 				case "Empty": return $this->strValue == null && $this->strName == null;
+				case "Anchor": return $this->strAnchor;
+				case "ControlId": return $this->strControlId;
+				case "Id": return $this->strControlId;
+
+				case "Text":
+					if ($this->strLabel) {
+						return $this->strLabel;
+					}
+					else {
+						return $this->strName;
+					}
+
 
 				default:
 					try {
@@ -146,6 +172,7 @@
 		 */
 		public function __set($strName, $mixValue) {
 			switch ($strName) {
+				case "Text":
 				case "Name":
 					try {
 						$this->strName = QType::Cast($mixValue, QType::String);
@@ -194,7 +221,23 @@
 						$objExc->IncrementOffset();
 						throw $objExc;
 					}
-										
+				case "Anchor":
+					try {
+						$this->strAnchor = QType::Cast($mixValue, QType::String);
+						break;
+					} catch (QInvalidCastException $objExc) {
+						$objExc->IncrementOffset();
+						throw $objExc;
+					}
+				case "Id":
+				case "ControlId":
+					try {
+						$this->strControlId = QType::Cast($mixValue, QType::String);
+						break;
+					} catch (QInvalidCastException $objExc) {
+						$objExc->IncrementOffset();
+						throw $objExc;
+					}
 				default:
 					try {
 						parent::__set($strName, $mixValue);

--- a/includes/base_controls/QListItemManager.trait.php
+++ b/includes/base_controls/QListItemManager.trait.php
@@ -1,0 +1,398 @@
+<?php
+	/**
+	 * QListItemManagerager.trait.php contains the QListItemManager trait
+	 * @package Controls
+	 */
+
+	/**
+	 * Since QListItems can be recursive, then logically both a QListControl, and a QListItem manages a collection of
+	 * QListItems. To prevent duplication of code, this trait is used by both to do that basic management of the
+	 * item list itself.
+	 *
+	 * @package Controls
+	 */
+	trait QListItemManager {
+		///////////////////////////
+		// Private Member Variables
+		///////////////////////////
+		/** @var QListItem[] an array of subitems if this is a recursive item.  */
+		protected $objListItemArray;
+
+		public function AddItem($mixListItemOrName, $strValue = null, $blnSelected = null, $strItemGroup = null, $mixOverrideParameters = null) {
+			if (gettype($mixListItemOrName) == QType::Object) {
+				$objListItem = QType::Cast($mixListItemOrName, "QListItem");
+			}
+			elseif ($mixOverrideParameters) {
+				// The OverrideParameters can only be included if they are not null, because OverrideAttributes in QBaseClass can't except a NULL Value
+				$objListItem = new QListItem($mixListItemOrName, $strValue, $blnSelected, $strItemGroup, $mixOverrideParameters);
+			}
+			else {
+				$objListItem = new QListItem($mixListItemOrName, $strValue, $blnSelected, $strItemGroup);
+			}
+
+			if ($strControlId = $objListItem->ControlId) {
+				$objListItem->ControlId = $this->ControlId . '_' . count($this->objListItemArray);	// auto assign the id based on parent id
+				$objListItem->Reindex();
+			}
+			$this->objListItemArray[] = $objListItem;
+			$this->_MarkAsModified();
+		}
+
+		/**
+		 * Allows you to add a ListItem at a certain index
+		 * Unlike AddItem, this will insert the ListItem at whatever index is passed to the function.  Additionally,
+		 * only a ListItem object can be passed (as opposed to an object or strings)
+		 *
+		 * @param integer   $intIndex    index at which the item should be inserted
+		 * @param QListItem $objListItem the ListItem which shall be inserted
+		 *
+		 * @throws QIndexOutOfRangeException
+		 * @throws Exception|QInvalidCastException
+		 */
+		public function AddItemAt($intIndex, QListItem $objListItem) {
+			try {
+				$intIndex = QType::Cast($intIndex, QType::Integer);
+			} catch (QInvalidCastException $objExc) {
+				$objExc->IncrementOffset();
+				throw $objExc;
+			}
+			if ($intIndex >= 0 &&
+				(!$this->objListItemArray && $intIndex == 0 ||
+					$intIndex <= count($this->objListItemArray))) {
+				for ($intCount = count($this->objListItemArray); $intCount > $intIndex; $intCount--) {
+					$this->objListItemArray[$intCount] = $this->objListItemArray[$intCount - 1];
+				}
+			} else {
+				throw new QIndexOutOfRangeException($intIndex, "AddItemAt()");
+			}
+
+			$this->objListItemArray[$intIndex] = $objListItem;
+			$this->Reindex();
+		}
+
+		/**
+		 * Reindex the ids of the items based on the current item.
+		 */
+		public function Reindex() {
+			if ($this->ControlId && $this->objListItemArray) for ($i = 0; $i < $this->GetItemCount(); $i++) {
+				$this->objListItemArray[$i]->ControlId = $this->ControlId . '_' . $i;	// assign the id based on parent id
+				$this->objListItemArray[$i]->Reindex();
+			}
+		}
+
+		/**
+		 * Stub function. If the object this is mixed in with is a control, then the control will override and implement.
+		 */
+		private function _MarkAsModified() {
+			if (method_exists($this, 'MarkAsModified')) {
+				$this->MarkAsModified();	// No current way around this. We are calling an unknown function, which makes this trait not self validated.
+			}
+		}
+
+
+		/**
+		 * Adds an array of items, or an array of key=>value pairs. Convenient for adding a list from a type table.
+		 * When passing key=>val pairs, mixSelectedValues can be an array, or just a single value to compare against to indicate what is selected.
+		 *
+		 * @param array  $mixItemArray          Array of QListItems or key=>val pairs.
+		 * @param mixed  $mixSelectedValues     Array of selected values, or value of one selection
+		 * @param string $strItemGroup          allows you to apply grouping (<optgroup> tag)
+		 * @param string $mixOverrideParameters OverrideParameters for ListItemStyle
+		 *
+		 * @throws Exception|QInvalidCastException
+		 */
+		public function AddItems(array $mixItemArray, $mixSelectedValues = null, $strItemGroup = null, $mixOverrideParameters = null) {
+			try {
+				$mixItemArray = QType::Cast($mixItemArray, QType::ArrayType);
+			} catch (QInvalidCastException $objExc) {
+				$objExc->IncrementOffset();
+				throw $objExc;
+			}
+
+			foreach ($mixItemArray as $val => $item) {
+				if ($val === '') {
+					$val = null; // these are equivalent when specified as a key of an array
+				}
+				if ($mixSelectedValues && is_array($mixSelectedValues)) {
+					$blnSelected = in_array($val, $mixSelectedValues);
+				} else {
+					$blnSelected = ($val === $mixSelectedValues);	// differentiate between null and 0 values
+				}
+				$this->AddItem($item, $val, $blnSelected, $strItemGroup, $mixOverrideParameters);
+			};
+			$this->Reindex();
+			$this->_MarkAsModified();
+		}
+
+		/**
+		 * Retrieve the ListItem at the specified index location
+		 *
+		 * @param integer $intIndex
+		 *
+		 * @throws QIndexOutOfRangeException
+		 * @throws Exception|QInvalidCastException
+		 * @return QListItem
+		 */
+		public function GetItem($intIndex) {
+			try {
+				$intIndex = QType::Cast($intIndex, QType::Integer);
+			} catch (QInvalidCastException $objExc) {
+				$objExc->IncrementOffset();
+				throw $objExc;
+			}
+			if (($intIndex < 0) ||
+				($intIndex >= count($this->objListItemArray)))
+				throw new QIndexOutOfRangeException($intIndex, "GetItem()");
+
+			return $this->objListItemArray[$intIndex];
+		}
+
+		/**
+		 * This will return an array of ALL the QListItems associated with this QListControl.
+		 * Please note that while each individual item can be altered, altering the array, itself,
+		 * will not affect any change on the QListControl.  So existing QListItems may be modified,
+		 * but to add / remove items from the QListControl, you should use AddItem() and RemoveItem().
+		 * @return QListItem[]
+		 */
+		public function GetAllItems() {
+			return $this->objListItemArray;
+		}
+
+		/**
+		 * Removes all the items in objListItemArray
+		 */
+		public function RemoveAllItems() {
+			$this->_MarkAsModified();
+			$this->objListItemArray = null;
+		}
+
+		/**
+		 * Removes a ListItem at the specified index location
+		 *
+		 * @param integer $intIndex
+		 *
+		 * @throws QIndexOutOfRangeException
+		 * @throws Exception|QInvalidCastException
+		 */
+		public function RemoveItem($intIndex) {
+			try {
+				$intIndex = QType::Cast($intIndex, QType::Integer);
+			} catch (QInvalidCastException $objExc) {
+				$objExc->IncrementOffset();
+				throw $objExc;
+			}
+			if (($intIndex < 0) ||
+				($intIndex > (count($this->objListItemArray) - 1)))
+				throw new QIndexOutOfRangeException($intIndex, "RemoveItem()");
+			for ($intCount = $intIndex; $intCount < count($this->objListItemArray) - 1; $intCount++) {
+				$this->objListItemArray[$intCount] = $this->objListItemArray[$intCount + 1];
+			}
+
+			$this->objListItemArray[$intCount] = null;
+			unset($this->objListItemArray[$intCount]);
+			$this->_MarkAsModified();
+			$this->Reindex();
+		}
+
+		/**
+		 * Replaces a QListItem at $intIndex. This combines the RemoveItem() and AddItemAt() operations.
+		 *
+		 * @param integer   $intIndex
+		 * @param QListItem $objListItem
+		 *
+		 * @throws Exception|QInvalidCastException
+		 */
+		public function ReplaceItem($intIndex, QListItem $objListItem) {
+			try {
+				$intIndex = QType::Cast($intIndex, QType::Integer);
+			} catch (QInvalidCastException $objExc) {
+				$objExc->IncrementOffset();
+				throw $objExc;
+			}
+			$objListItem->ControlId = $this->ControlId . '_' . $intIndex;
+			$this->objListItemArray[$intIndex] = $objListItem;
+			$objListItem->Reindex();
+			$this->_MarkAsModified();
+		}
+
+		/**
+		 * Finds the item by id recursively. Makes use of the fact that we maintain the ids in order to efficiently
+		 * find the item.
+		 *
+		 * @param string $strId If this is a sub-item, it will be an id fragment
+		 * @return null|QListItem
+		 */
+		public function FindItem($strId) {
+			$objFoundItem = null;
+			$a = explode ('_', $strId, 3);
+			if (isset($a[1]) &&
+					$this->objListItemArray &&	// just in case
+					$a[1] < count ($this->objListItemArray)) {	// just in case
+				$objFoundItem = $this->objListItemArray[$a[1]];
+			}
+			if (isset($a[2])) {
+				$objFoundItem = $objFoundItem->FindItem ($a[1] . '_' . $a[2]);
+			}
+
+			return $objFoundItem;
+		}
+
+		public function GetItemCount($blnRecursive = false) {
+			$count = 0;
+			if ($this->objListItemArray) {
+				$count = count($this->objListItemArray);
+				if ($blnRecursive) {
+					foreach ($this->objListItemArray as $objListItem) {
+						$count += $objListItem->GetItemCount(true);
+					}
+				}
+			}
+			return $count;
+		}
+
+		/**
+		 * Recursively unselects all the items and subitems in the list.
+		 *
+		 * @param bool $blnMarkAsModified
+		 */
+		public function UnselectAllItems($blnMarkAsModified = true) {
+			$intCount = $this->GetItemCount();
+			for ($intIndex = 0; $intIndex < $intCount; $intIndex++) {
+				$objItem = $this->GetItem($intIndex);
+				$objItem->Selected = false;
+				if ($objItem->GetItemCount()) {
+					$objItem->UnselectAllItems(false);
+				}
+			}
+			if ($blnMarkAsModified) {
+				$this->_MarkAsModified();
+			}
+		}
+
+
+		/**
+		 * Selects the given items by Id, and unselects items that are not in the list.
+		 * @param string[] $strIdArray
+		 * @param bool $blnMarkAsModified
+		 */
+		public function SetSelectedItemsById(array $strIdArray, $blnMarkAsModified = true) {
+			$intCount = $this->GetItemCount();
+			for ($intIndex = 0; $intIndex < $intCount; $intIndex++) {
+				$objItem = $this->GetItem($intIndex);
+				$strId = $objItem->ControlId;
+				$objItem->Selected = in_array($strId, $strIdArray);
+				if ($objItem->GetItemCount()) {
+					$objItem->SetSelectedItemsById($strIdArray, false);
+				}
+			}
+			if ($blnMarkAsModified) {
+				$this->_MarkAsModified();
+			}
+		}
+
+		/**
+		 * Set the selected item by index. This can only set top level items. Lower level items are untouched.
+		 * @param integer[] $intIndexArray
+		 * @param bool $blnMarkAsModified
+		 */
+		public function SetSelectedItemsByIndex(array $intIndexArray, $blnMarkAsModified = true) {
+			$intCount = $this->GetItemCount();
+			for ($intIndex = 0; $intIndex < $intCount; $intIndex++) {
+				$objItem = $this->GetItem($intIndex);
+				$objItem->Selected = in_array($intIndex, $intIndexArray);
+			}
+			if ($blnMarkAsModified) {
+				$this->_MarkAsModified();
+			}
+		}
+
+		/**
+		 * Set the selected items by value. We equate nulls and empty strings, but must be careful not to equate
+		 * those with a zero.
+		 *
+		 * @param array $mixValueArray
+		 * @param bool $blnMarkAsModified
+		 */
+		public function SetSelectedItemsByValue(array $mixValueArray, $blnMarkAsModified = true) {
+			$intCount = $this->GetItemCount();
+
+			for ($intIndex = 0; $intIndex < $intCount; $intIndex++) {
+				$objItem = $this->GetItem($intIndex);
+				$mixCurVal = $objItem->Value;
+				$blnSelected = false;
+				foreach ($mixValueArray as $mixValue) {
+					if (!$mixValue) {
+						if ($mixValue === null || $mixValue === '') {
+							if ($mixCurVal === null || $mixCurVal === '') {
+								$blnSelected = true;
+							}
+						} else {
+							if (!($mixCurVal === null || $mixCurVal === '')) {
+								$$blnSelected = true;
+							}
+						}
+					}
+					elseif ($mixCurVal == $mixValue) {
+						$blnSelected = true;
+					}
+				}
+				$objItem->Selected = $blnSelected;
+			}
+			if ($blnMarkAsModified) {
+				$this->_MarkAsModified();
+			}
+		}
+
+
+		/**
+		 * Set the selected items by name.
+		 * @param string[] $strNameArray
+		 * @param bool $blnMarkAsModified
+		 */
+		public function SetSelectedItemsByName(array $strNameArray, $blnMarkAsModified = true) {
+			$intCount = $this->GetItemCount();
+			for ($intIndex = 0; $intIndex < $intCount; $intIndex++) {
+				$objItem = $this->GetItem($intIndex);
+				$strName = $objItem->Name;
+				$objItem->Selected = in_array($strName, $strNameArray);
+				if ($objItem->GetItemCount()) {
+					$objItem->SetSelectedItemsByName($strNameArray, false);
+				}
+			}
+			if ($blnMarkAsModified) {
+				$this->_MarkAsModified();
+			}
+		}
+
+
+		public function GetFirstSelectedItem() {
+			$intCount = $this->GetItemCount();
+			for ($intIndex = 0; $intIndex < $intCount; $intIndex++) {
+				$objItem = $this->GetItem($intIndex);
+				if ($objItem->Selected) {
+					return $objItem;
+				}
+				if ($objItem2 = $objItem->GetFirstSelectedItem()) {
+					return $objItem2;
+				}
+			}
+			return null;
+		}
+
+		public function GetSelectedItems() {
+			$aResult = array();
+			$intCount = $this->GetItemCount();
+			for ($intIndex = 0; $intIndex < $intCount; $intIndex++) {
+				$objItem = $this->GetItem($intIndex);
+				if ($objItem->Selected) {
+					$aResult[] = $objItem;
+				}
+				if ($objItems = $objItem->GetSelectedItems()) {
+					$aResult = array_merge ($aResult, $objItems);
+				}
+			}
+			return $aResult;
+		}
+
+
+	}

--- a/includes/base_controls/QListItemStyle.class.php
+++ b/includes/base_controls/QListItemStyle.class.php
@@ -5,9 +5,7 @@
 	 */
 
 	/**
-	 * This defines the style for an Item for a ListBox
-	 * All the appearance properties should be self-explanatory.
-	 * For more information about ListItem appearance, please see QListItem.class.php
+	 * This defines the style for an Item for a QListControl, which is the base for many different list types.
 	 *
 	 * @package Controls
 	 */

--- a/includes/base_controls/QRadioButtonList.class.php
+++ b/includes/base_controls/QRadioButtonList.class.php
@@ -70,16 +70,10 @@
 				$this->SelectedIndex = $_POST[$this->strControlId];
 			}
 			elseif ($this->objForm->IsCheckableControlRendered($this->strControlId)) {
-				if (array_key_exists($this->strControlId, $_POST)) {
-					for ($intIndex = 0; $intIndex < count($this->objItemsArray); $intIndex++) {
-						if ($_POST[$this->strControlId] == $intIndex)
-							$this->objItemsArray[$intIndex]->Selected = true;
-						else
-							$this->objItemsArray[$intIndex]->Selected = false;
-					}
+				if (isset($_POST[$this->strControlId])) {
+					$this->SetSelectedItemsByIndex(array($_POST[$this->strControlId]), false);
 				} else {
-					for ($intIndex = 0; $intIndex < count($this->objItemsArray); $intIndex++) 
-						$this->objItemsArray[$intIndex]->Selected = false;
+					$this->UnselectAllItems(false);
 				}
 			}
 		}
@@ -147,8 +141,8 @@
 		}
 
 		protected function GetControlHtml() {
-			if ((!$this->objItemsArray) || (count($this->objItemsArray) == 0))
-				return "";
+			$intItemCount = $this->GetItemCount();
+			if (!$intItemCount) return '';
 
 			/* Deprecated. Use Margin and Padding on the ItemStyle attribute.
 			if ($this->intCellPadding >= 0)
@@ -217,7 +211,7 @@
 								+ min(($this->ItemCount % $this->intRepeatColumns), $intColIndex)
 								+ $intRowIndex;
 
-						$strItemHtml = $this->GetItemHtml($this->objItemsArray[$intIndex], $intIndex, $this->GetHtmlAttribute('tabindex'), $this->blnWrapLabel);
+						$strItemHtml = $this->GetItemHtml($this->GetItem($intIndex), $intIndex, $this->GetHtmlAttribute('tabindex'), $this->blnWrapLabel);
 						$strCellHtml = QHtml::RenderTag ('td', null, $strItemHtml);
 						$strRowHtml .= $strCellHtml;
 					}
@@ -239,7 +233,7 @@
 			$count = $this->ItemCount;
 			$strToReturn = '';
 			for ($intIndex = 0; $intIndex < $count; $intIndex++) {
-				$strToReturn .= $this->GetItemHtml($this->objItemsArray[$intIndex], $intIndex, $this->GetHtmlAttribute('tabindex'), $this->blnWrapLabel) . "\n";
+				$strToReturn .= $this->GetItemHtml($this->GetItem($intIndex), $intIndex, $this->GetHtmlAttribute('tabindex'), $this->blnWrapLabel) . "\n";
 			}
 			$strToReturn = $this->RenderTag('div', ['id'=>$this->strControlId], null, $strToReturn);
 			return $strToReturn;
@@ -253,7 +247,7 @@
 			$count = $this->ItemCount;
 			$strToReturn = '';
 			for ($intIndex = 0; $intIndex < $count; $intIndex++) {
-				$strHtml = $this->GetItemHtml($this->objItemsArray[$intIndex], $intIndex, $this->GetHtmlAttribute('tabindex'), $this->blnWrapLabel);
+				$strHtml = $this->GetItemHtml($this->GetItem($intIndex), $intIndex, $this->GetHtmlAttribute('tabindex'), $this->blnWrapLabel);
 				$strToReturn .= QHtml::RenderTag('div', null, $strHtml);
 			}
 			$strToReturn = $this->RenderTag('div', ['id'=>$this->strControlId], null, $strToReturn);

--- a/includes/qcubed.inc.php
+++ b/includes/qcubed.inc.php
@@ -173,6 +173,7 @@
 
 	QApplicationBase::$ClassFile['qlistcontrol'] = __QCUBED_CORE__ . '/base_controls/QListControl.class.php';
 	QApplicationBase::$ClassFile['qlistitem'] = __QCUBED_CORE__ . '/base_controls/QListItem.class.php';
+	QApplicationBase::$ClassFile['qlistitemmanager'] = __QCUBED_CORE__ . '/base_controls/QListItemManager.trait.php';
 	QApplicationBase::$ClassFile['qlistboxbase'] = __QCUBED_CORE__ . '/base_controls/QListBoxBase.class.php';
 	QApplicationBase::$ClassFile['qlistbox'] = __QCUBED__ . '/controls/QListBox.class.php';
 	QApplicationBase::$ClassFile['qlistitemstyle'] = __QCUBED_CORE__ . '/base_controls/QListItemStyle.class.php';
@@ -181,7 +182,6 @@
 	QApplicationBase::$ClassFile['qtreenav'] = __QCUBED_CORE__ . '/base_controls/QTreeNav.class.php';
 	QApplicationBase::$ClassFile['qtreenavitem'] = __QCUBED_CORE__ . '/base_controls/QTreeNavItem.class.php';
 	QApplicationBase::$ClassFile['qhtmllist'] = __QCUBED_CORE__ . '/base_controls/QHtmlList.class.php';
-	QApplicationBase::$ClassFile['qhtmllistitem'] = __QCUBED_CORE__ . '/base_controls/QHtmlList.class.php';
 
 	QApplicationBase::$ClassFile['qtextboxbase'] = __QCUBED_CORE__ . '/base_controls/QTextBoxBase.class.php';
 	QApplicationBase::$ClassFile['qtextbox'] = __QCUBED__ . '/controls/QTextBox.class.php';


### PR DESCRIPTION
Per previous suggestion of @olegabr, this is a refactoring of list items to make QHtmlList a QListControl. Its a little messy at the QListItem level, because it has to serve dual purposes, but it is likely that many javascript widgets that would use an HtmlList as the base would need the QItemList functionality, like having Selected items, Values, and such. The other odd thing for a QListBox is the QListItem can have sub items. However, the HTML spec says that this is a possible future addition to the spec through the optgroup tag, so its not that big a stretch.

QHtmlList is now a QListControl.
QListItem is now a hierarchical item.
QListControls do not expose their value to the client. Since that is often a database id, this was a security risk. Value is still accessible in PHP though.