### PR TITLE
feature-ListItemRefactor

### DIFF
--- a/assets/php/examples/basic_qform/hlist.php
+++ b/assets/php/examples/basic_qform/hlist.php
@@ -1,0 +1,44 @@
+<?php
+require_once('../qcubed.inc.php');
+
+// Define the Qform with all our Qcontrols
+class ExamplesForm extends QForm {
+
+	protected $lstProjects;
+
+	// Initialize our Controls during the Form Creation process
+	protected function Form_Create() {
+		// Define the ListBox, and create the first listitem as 'Select One'
+		$this->lstProjects = new QHListControl($this);
+		$this->lstProjects->SetDataBinder(array ($this, 'lstProjects_Bind'));
+		$this->lstProjects->UnorderedListStyle = QUnorderedListStyle::Square;
+
+	}
+
+	/**
+	 * Add the items to the project list.
+	 */
+	public function lstProjects_Bind() {
+		$clauses[] = QQ::ExpandAsArray (QQN::Project()->PersonAsTeamMember);
+		$objProjects = Project::QueryArray(QQ::All(), $clauses);
+
+		foreach ($objProjects as $objProject) {
+			$item = new QHListItem ($objProject->Name);
+			$item->Tag = 'ol';
+			$item->GetSubTagStyler()->OrderedListType = QOrderedListType::LowercaseRoman;
+			foreach ($objProject->_PersonAsTeamMemberArray as $objPerson) {
+				/****
+				 * Here we add a sub-item to each item before adding the item to the main list.
+				 */
+				$item->AddItem ($objPerson->FirstName . ' ' . $objPerson->LastName);
+			}
+			$this->lstProjects->AddItem ($item);
+		}
+	}
+
+}
+
+// Run the Form we have defined
+// The QForm engine will look to intro.tpl.php to use as its HTML template include file
+ExamplesForm::Run('ExamplesForm');
+?>

--- a/assets/php/examples/basic_qform/hlist.tpl.php
+++ b/assets/php/examples/basic_qform/hlist.tpl.php
@@ -1,0 +1,36 @@
+<?php require('../includes/header.inc.php'); ?>
+<?php $this->RenderBegin(); ?>
+
+<div id="instructions">
+	<h1>Generating Html Lists</h1>
+
+	<p><strong>QHListControl</strong> lets you create ordered or unordered hierarchical html lists of arbitarty depth.
+		Its interface is very similar to the QListControl controls, but also adds the ability to use a data binder
+	    to get the list of items to display.</p>
+
+	<p>Using the data binder is optional, and in some cases is advantageous to not using the databinder. If you don't
+	   use a databinder, all the list's items are stored in the Formstate object, which means that the data is serialized
+	   and restored every time the user does any kind of action on the screen that requires a response from the server.
+	   If you have a long list, that can take a lot of space and time. </p>
+
+	<p>By using a databinder, the items are only created when the list is drawn, and then are immediately deleted.
+		This saves space, but means the items are no longer available to be queried later if you need to know
+	    information about the list. Depending on your application, this might be OK. Also, depending on your application,
+	    there may be other ways of getting the data you need without storing the entire item list.</p>
+
+	<p>A plain html list may not be all that exciting, but many 3rd party javascript and css widgets use html lists
+	   as the foundation to create menus, navigation bars, collapsible trees, and more, making the <strong>QHListControl</strong>
+	   an excellent candidate for the base of such a control. See some of our plugins for examples.</p>
+
+	<p>In this example we create a <strong>QHListControl</strong> using an expanded project list. The expansion lets
+	   us add project members to each project item, and then add the project item to the main list.</p>
+
+</div>
+
+<div id="demoZone">
+
+	<?php $this->lstProjects->Render(); ?></p>
+</div>
+
+<?php $this->RenderEnd(); ?>
+<?php require('../includes/footer.inc.php'); ?>

--- a/assets/php/examples/basic_qform/listbox.php
+++ b/assets/php/examples/basic_qform/listbox.php
@@ -9,6 +9,8 @@ class ExamplesForm extends QForm {
 	// A listbox of Persons
 	protected $lstPersons;
 
+	protected $chkPersons;
+
 	// Initialize our Controls during the Form Creation process
 	protected function Form_Create() {
 		// Define our Label
@@ -30,6 +32,19 @@ class ExamplesForm extends QForm {
 		}
 		// Declare a QChangeEvent to call a server action: the lstPersons_Change PHP method
 		$this->lstPersons->AddAction(new QChangeEvent(), new QServerAction('lstPersons_Change'));
+
+		// Do the same but with a multiple selection QCheckboxList
+		$this->chkPersons = new QCheckBoxList($this);
+		if ($objPersons){
+			foreach ($objPersons as $objPerson) {
+				// We want to display the listitem as Last Name, First Name
+				// and the VALUE of the listitem will be the database id
+				$this->chkPersons->AddItem($objPerson->FirstName . ' ' . $objPerson->LastName, $objPerson->Id);
+			}
+		}
+		$this->chkPersons->RepeatColumns = 2;
+		$this->chkPersons->AddAction(new QChangeEvent(), new QServerAction('chkPersons_Change'));
+
 	}
 
 	// Handle the changing of the listbox
@@ -49,6 +64,21 @@ class ExamplesForm extends QForm {
 			$this->lblMessage->Text = '<None>';
 		}
 	}
+
+	// Handle the changing of the checkbox list
+	protected function chkPersons_Change($strFormId, $strControlId, $strParameter) {
+		// In this example, since our values are database ids, we use the ids to lookup the names and display them.
+
+		$names = $this->chkPersons->SelectedNames;
+
+		if ($names) {
+			$this->lblMessage->Text = implode (", ", $names);
+		} else {
+			// No one was selected
+			$this->lblMessage->Text = '<None>';
+		}
+	}
+
 }
 
 // Run the Form we have defined

--- a/assets/php/examples/basic_qform/listbox.tpl.php
+++ b/assets/php/examples/basic_qform/listbox.tpl.php
@@ -15,26 +15,24 @@
 		<strong>QRadioButtonList</strong> controls which all inherit from QListControl to allow you to
 		present the data and functionality that you need to in the most user-friendly way possible.</p>
 
-	<p>In this example we create a <strong>QListBox</strong> control.  This single-select listbox will pull its data
+	<p>In this example we create a <strong>QListBox</strong> and <strong>QCheckbox</strong> control.  They pull their data
 		from the <strong>Person</strong> table in the database.  Also, if you select a person, we will update the
 		<strong>lblMessage</strong> label to show what you have selected.</p>
 
 	<p>If you do a <strong>View Source...</strong> in your browser to view the HTML,
-		you'll note that the &lt;option&gt; values are arbitrary indexes (starting with 0).  This is
-		done intentionally.  <strong>QListControl</strong> uses arbitrary listcontrol indexes to lookup the specific
-		value that was assigned to that <strong>QListItem</strong>.  It allows you to do things like put in non-string
-		based data into the value, or even to have multiple listitems point have the same exact value.</p>
-
-	<p>And in fact, this is what we have done.  The actual value of each <strong>QListItem</strong> is <i>not</i> a
-		<strong>Person</strong> Id, but it is in fact the <strong>Person</strong> object, itself.  Note that in our
-		<strong>lstPersons_Change</strong>, we never need to re-lookup the <strong>Person</strong> via a <strong>Person::Load</strong>.  We
-		simply display the <strong>Person's</strong> name directly from the object that is returned by the <strong>SelectedValue</strong>
-		call on our <strong>QListBox</strong>.</p>
+		you'll note that the <strong>value</strong> attributes in the &lt;option&gt; tags are indexes (starting with 0)
+		and not the values assigned in the PHP code.  This is done intentionally as a security measure to prevent database
+		indexes from being sent to the browser, and to allow for non-string based values, or even duplicate values.
+		You can lookup specific values in the <strong>QListControl</strong> by using the <strong>SelectedValue</strong>
+		attribute. You can also lookup selected Names, Ids, and get the whole <strong>QListItem</strong>.</p>
 </div>
 
 <div id="demoZone">
-	<p><?php $this->lstPersons->Render(); ?></p>
-	<p>Currently Selected: <?php $this->lblMessage->Render(); ?></p>
+
+	<p><label>List 1</label><?php $this->lstPersons->Render(); ?></p>
+	<p><label>List 2</label><?php $this->chkPersons->Render(); ?></p>
+
+	<p>Recently Selected: <?php $this->lblMessage->Render(); ?></p>
 </div>
 
 <?php $this->RenderEnd(); ?>

--- a/assets/php/examples/includes/examples.inc.php
+++ b/assets/php/examples/includes/examples.inc.php
@@ -67,6 +67,7 @@
 			self::AddCoreExampleFile($intIndex, '/basic_qform/calculator_2.php Calculator Example with Validation');
 			self::AddCoreExampleFile($intIndex, '/basic_qform/calculator_3.php Calculator Example with &quot;Design&quot;');
 			self::AddCoreExampleFile($intIndex, '/basic_qform/listbox.php * Introduction to QListControl');
+			self::AddCoreExampleFile($intIndex, '/basic_qform/hlist.php * Generating Html Lists');
 			self::AddCoreExampleFile($intIndex, '/basic_qform/textbox.php * Introduction to QTextBoxControls');
 			
 			$intIndex++;

--- a/assets/php/tests/ui_basic.php
+++ b/assets/php/tests/ui_basic.php
@@ -99,6 +99,7 @@
 			$this->lstSelect->Warning = 'Value = ' . $this->lstSelect->SelectedValue;
 			$this->lstSelect2->Warning = 'Values = ' . implode (',', $this->lstSelect2->SelectedValues);
 			$this->lstCheck->Warning = 'Values = ' . implode (',', $this->lstCheck->SelectedValues);
+			$this->lstCheck2->Warning = 'Values = ' . implode (',', $this->lstCheck2->SelectedValues);
 			$this->lstRadio->Warning = 'Value = ' . $this->lstRadio->SelectedValue;
 			$this->rdoRadio1->Warning = 'Value = ' . $this->rdoRadio1->Checked;
 			$this->rdoRadio2->Warning = 'Value = ' . $this->rdoRadio2->Checked;

--- a/assets/php/tests/ui_hlist.php
+++ b/assets/php/tests/ui_hlist.php
@@ -7,17 +7,21 @@
 		protected $btnServer;
 		protected $btnAjax;
 
-		protected function Form_Create() {
-			$this->list1 = new QHtmlList($this);
-			$this->list1->Name = 'List';
+		protected $a;
 
-			$a = [new QListItem ('A', 1),
-				new QListItem ('B', 2),
-				new QListItem ('C', 3),
-				new QListItem ('D', 4)
+
+		protected function Form_Create() {
+			$this->a = [new QHListItem ('A', 1),
+				new QHListItem ('B', 2),
+				new QHListItem ('C', 3),
+				new QHListItem ('D', 4)
 			];
 
-			$this->list1->AddItems($a);
+			$this->list1 = new QHListControl($this);
+			$this->list1->Name = 'List';
+
+
+			$this->list1->AddItems($this->a);
 			$this->list1->SetDataBinder([$this, 'DataBind']);
 
 			$this->btnServer = new QButton ($this);
@@ -33,17 +37,12 @@
 		}
 
 		public function DataBind() {
-			$a = [new QListItem ('A', 1),
-				new QListItem ('B', 2),
-				new QListItem ('C', 3),
-				new QListItem ('D', 4)
-			];
 
-			$a[0]->AddItems(['aa'=>0, 'ab'=>2, 'ac'=>3]);
-			$a[1]->AddItems(['ba'=>0, 'bb'=>1]);
+			$this->a[0]->AddItems(['aa'=>0, 'ab'=>2, 'ac'=>3]);
+			$this->a[1]->AddItems(['ba'=>0, 'bb'=>1]);
 
 			$this->list1->RemoveAllItems();
-			$this->list1->AddItems($a);
+			$this->list1->AddListItems($this->a);
 		}
 		
 	}

--- a/assets/php/tests/ui_hlist.php
+++ b/assets/php/tests/ui_hlist.php
@@ -1,0 +1,51 @@
+<?php
+    require_once('../qcubed.inc.php');
+    
+	class SelectForm extends QForm {
+		protected $list1;
+
+		protected $btnServer;
+		protected $btnAjax;
+
+		protected function Form_Create() {
+			$this->list1 = new QHtmlList($this);
+			$this->list1->Name = 'List';
+
+			$a = [new QListItem ('A', 1),
+				new QListItem ('B', 2),
+				new QListItem ('C', 3),
+				new QListItem ('D', 4)
+			];
+
+			$this->list1->AddItems($a);
+			$this->list1->SetDataBinder([$this, 'DataBind']);
+
+			$this->btnServer = new QButton ($this);
+			$this->btnServer->Text = 'Server Submit';
+			$this->btnServer->AddAction(new QClickEvent(), new QServerAction('submit_click'));
+
+			$this->btnAjax = new QButton ($this);
+			$this->btnAjax->Text = 'Ajax Submit';
+			$this->btnAjax->AddAction(new QClickEvent(), new QAjaxAction('submit_click'));
+		}
+
+		protected function submit_click($strFormId, $strControlId, $strParameter) {
+		}
+
+		public function DataBind() {
+			$a = [new QListItem ('A', 1),
+				new QListItem ('B', 2),
+				new QListItem ('C', 3),
+				new QListItem ('D', 4)
+			];
+
+			$a[0]->AddItems(['aa'=>0, 'ab'=>2, 'ac'=>3]);
+			$a[1]->AddItems(['ba'=>0, 'bb'=>1]);
+
+			$this->list1->RemoveAllItems();
+			$this->list1->AddItems($a);
+		}
+		
+	}
+	SelectForm::Run('SelectForm');
+?>

--- a/assets/php/tests/ui_hlist.tpl.php
+++ b/assets/php/tests/ui_hlist.tpl.php
@@ -1,0 +1,7 @@
+<?php require('../../../../../../project/includes/configuration/header.inc.php'); ?>
+<?php $this->RenderBegin(); ?>
+<?php $this->list1->RenderWithName(); ?>
+<?php $this->btnServer->Render(); ?>
+<?php $this->btnAjax->Render(); ?>
+<?php $this->RenderEnd(); ?>
+<?php require('../../../../../../project/includes/configuration/footer.inc.php'); ?>

--- a/includes/base_controls/QAutocompleteBase.class.php
+++ b/includes/base_controls/QAutocompleteBase.class.php
@@ -225,6 +225,7 @@
 					break;
 					
 				case "SelectedValue":	// mirror list control
+				case "Value":
 				case 'SelectedId':
 					// Set this at creation time to initialize the selected id. 
 					// This is also set by the javascript above to keep track of subsequent selections made by the user.
@@ -280,6 +281,7 @@
 		public function __get($strName) {
 			switch ($strName) {
 				case "SelectedValue":	// mirror list control
+				case "Value": // most common situation
 				case 'SelectedId': return $this->strSelectedId;
 
 				default: 

--- a/includes/base_controls/QCheckBoxList.class.php
+++ b/includes/base_controls/QCheckBoxList.class.php
@@ -82,7 +82,12 @@
 				}
 			}
 		}
-		
+
+		/**
+		 * Return the javascript associated with the control.
+		 *
+		 * @return string
+		 */
 		public function GetEndScript() {
 			$strScript = sprintf ('$j("#%s").on("change", "input", qc.formObjChanged);', $this->ControlId); // detect change for framework
 
@@ -97,7 +102,16 @@
 			return $strScript;
 		}
 
-		protected function GetItemHtml($objItem, $intIndex, $strTabIndex, $blnWrapLabel) {
+		/**
+		 * Return the HTML for the given item.
+		 *
+		 * @param QListItem $objItem
+		 * @param integer $intIndex
+		 * @param string $strTabIndex
+		 * @param boolean $blnWrapLabel
+		 * @return string
+		 */
+		protected function GetItemHtml(QListItem $objItem, $intIndex, $strTabIndex, $blnWrapLabel) {
 			$objLabelStyles = new QTagStyler();
 			if ($this->objItemStyle) {
 				$objLabelStyles->Override($this->objItemStyle); // default style
@@ -110,7 +124,7 @@
 			$objStyles->SetHtmlAttribute('type', 'checkbox');
 			$objStyles->SetHtmlAttribute('name', $this->strControlId . '[' . $intIndex . ']');
 
-			$strIndexedId = $objItem->ControlId;
+			$strIndexedId = $objItem->Id;
 			$objStyles->SetHtmlAttribute('id', $strIndexedId);
 			if ($strTabIndex) {
 				$objStyles->TabIndex = $strTabIndex;
@@ -145,6 +159,10 @@
 			return $strHtml;
 		}
 
+		/**
+		 * Return the html to draw the base control.
+		 * @return string
+		 */
 		protected function GetControlHtml() {
 			if ((!$this->objListItemArray) || (count($this->objListItemArray) == 0))
 				return "";
@@ -260,6 +278,10 @@
 		}
 
 
+		/**
+		 * Validate the control.
+		 * @return bool
+		 */
 		public function Validate() {
 			if ($this->blnRequired) {
 				if ($this->SelectedIndex == -1) {

--- a/includes/base_controls/QCheckBoxList.class.php
+++ b/includes/base_controls/QCheckBoxList.class.php
@@ -70,24 +70,15 @@
 		public function ParsePostData() {
 			if (QApplication::$RequestMode == QRequestMode::Ajax) {
 				// Ajax will only send information about controls that are on the screen, so we know they are rendered
-				for ($intIndex = 0; $intIndex < count($this->objItemsArray); $intIndex++) {
-					if (!empty($_POST[$this->strControlId][$intIndex]))
-						$this->objItemsArray[$intIndex]->Selected = true;
-					else
-						$this->objItemsArray[$intIndex]->Selected = false;
-				}
+				$a = array_keys($_POST[$this->strControlId]);
+				$this->SetSelectedItemsByIndex($a, false);
 			}
 			elseif ($this->objForm->IsCheckableControlRendered($this->strControlId)) {
 				if ((array_key_exists($this->strControlId, $_POST)) && (is_array($_POST[$this->strControlId]))) {
-					for ($intIndex = 0; $intIndex < count($this->objItemsArray); $intIndex++) {
-						if (array_key_exists($intIndex, $_POST[$this->strControlId]))
-							$this->objItemsArray[$intIndex]->Selected = true;
-						else
-							$this->objItemsArray[$intIndex]->Selected = false;
-					}
+					$a = array_keys($_POST[$this->strControlId]);
+					$this->SetSelectedItemsByIndex($a, false);
 				} else {
-					for ($intIndex = 0; $intIndex < count($this->objItemsArray); $intIndex++) 
-						$this->objItemsArray[$intIndex]->Selected = false;
+					$this->UnselectAllItems(false);
 				}
 			}
 		}
@@ -119,7 +110,7 @@
 			$objStyles->SetHtmlAttribute('type', 'checkbox');
 			$objStyles->SetHtmlAttribute('name', $this->strControlId . '[' . $intIndex . ']');
 
-			$strIndexedId = $this->strControlId . '_' . $intIndex;
+			$strIndexedId = $objItem->ControlId;
 			$objStyles->SetHtmlAttribute('id', $strIndexedId);
 			if ($strTabIndex) {
 				$objStyles->TabIndex = $strTabIndex;
@@ -155,7 +146,7 @@
 		}
 
 		protected function GetControlHtml() {
-			if ((!$this->objItemsArray) || (count($this->objItemsArray) == 0))
+			if ((!$this->objListItemArray) || (count($this->objListItemArray) == 0))
 				return "";
 
 			/* Deprecated. Use Margin and Padding on the ItemStyle attribute.
@@ -225,7 +216,7 @@
 								+ min(($this->ItemCount % $this->intRepeatColumns), $intColIndex)
 								+ $intRowIndex;
 
-						$strItemHtml = $this->GetItemHtml($this->objItemsArray[$intIndex], $intIndex, $this->GetHtmlAttribute('tabindex'), $this->blnWrapLabel);
+						$strItemHtml = $this->GetItemHtml($this->objListItemArray[$intIndex], $intIndex, $this->GetHtmlAttribute('tabindex'), $this->blnWrapLabel);
 						$strCellHtml = QHtml::RenderTag ('td', null, $strItemHtml);
 						$strRowHtml .= $strCellHtml;
 					}
@@ -247,7 +238,7 @@
 			$count = $this->ItemCount;
 			$strToReturn = '';
 			for ($intIndex = 0; $intIndex < $count; $intIndex++) {
-				$strToReturn .= $this->GetItemHtml($this->objItemsArray[$intIndex], $intIndex, $this->GetHtmlAttribute('tabindex'), $this->blnWrapLabel) . "\n";
+				$strToReturn .= $this->GetItemHtml($this->objListItemArray[$intIndex], $intIndex, $this->GetHtmlAttribute('tabindex'), $this->blnWrapLabel) . "\n";
 			}
 			$strToReturn = $this->RenderTag('div', ['id'=>$this->strControlId], null, $strToReturn);
 			return $strToReturn;
@@ -261,7 +252,7 @@
 			$count = $this->ItemCount;
 			$strToReturn = '';
 			for ($intIndex = 0; $intIndex < $count; $intIndex++) {
-				$strHtml = $this->GetItemHtml($this->objItemsArray[$intIndex], $intIndex, $this->GetHtmlAttribute('tabindex'), $this->blnWrapLabel);
+				$strHtml = $this->GetItemHtml($this->objListItemArray[$intIndex], $intIndex, $this->GetHtmlAttribute('tabindex'), $this->blnWrapLabel);
 				$strToReturn .= QHtml::RenderTag('div', null, $strHtml);
 			}
 			$strToReturn = $this->RenderTag('div', ['id'=>$this->strControlId], null, $strToReturn);

--- a/includes/base_controls/QControlBase.class.php
+++ b/includes/base_controls/QControlBase.class.php
@@ -1747,6 +1747,14 @@
 			return $this->objWrapperStyler;
 		}
 
+		/**
+		 * Returns the form associated with the control. Used by the QDataBinder trait.
+		 * @return QForm
+		 */
+		public function GetForm() {
+			return $this->objForm;
+		}
+
 		/////////////////////////
 		// Public Properties: GET
 		/////////////////////////

--- a/includes/base_controls/QDataBinder.trait.php
+++ b/includes/base_controls/QDataBinder.trait.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Contains the DataBinder trait
+ */
+
+/**
+ * Trait QDataBinder
+ * The QDataBinder trait encapsulates the functionality of data binding for multiple controls that would like to make
+ * use of it. Data binding lets you only recall data during draw time, thus saving space, because the data is not
+ * saved with the formstate. Controls that use this will have to be sure to unload the data after drawing as needed.
+ *
+ * There are a couple of modes of this. A legacy mode use strings to record the function names. The more modern way uses
+ * an array as a callable.
+ */
+trait QDataBinder {
+	protected $objDataBinder;
+
+	/**
+	 * Sets the data binder. Allows it to be sent in a couple of different ways:
+	 * - legacy mode: method name followed by optional control to call the method on. If not specified, will call on the form.
+	 * - modern mode: a php callable.
+	 * @param callable|string $mixMethodName
+	 * @param null|QForm|QControl $objParentControl
+	 */
+	public function SetDataBinder($mixMethodName, $objParentControl = null) {
+		if (is_callable($mixMethodName)) {
+			$this->objDataBinder = $mixMethodName;
+		} elseif (is_string ($mixMethodName)) {
+			if (!$objParentControl) {
+				$objParentControl = $this->GetForm();
+			}
+			$this->objDataBinder = array($objParentControl, $mixMethodName);
+		}
+		else {
+			assert('false');	// Improperly specified data binder
+		}
+	}
+
+	/**
+	 * Bind the data by calling the data binder. Will pass the current control as the parameter to the data binder.
+	 * @throws Exception
+	 * @throws QCallerException
+	 */
+	public function CallDataBinder() {
+		if ($this->objDataBinder) {
+			if (is_array($this->objDataBinder) && $this->objDataBinder[0] instanceof QForm) {
+				$this->objDataBinder[0]->CallDataBinder($this->objDataBinder, $this);
+			}
+			else {
+				try {
+					call_user_func($this->objDataBinder, $this);
+				} catch (QCallerException $objExc) {
+					$objExc->IncrementOffset();
+					throw $objExc;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Check the binder for a reference to the form.
+	 */
+	public function Sleep() {
+		$this->objDataBinder = QControl::SleepHelper ($this->objDataBinder);
+		parent::Sleep();
+	}
+
+	/**
+	 * @param QForm $objForm
+	 */
+	public function Wakeup(QForm $objForm) {
+		parent::Wakeup($objForm);
+		$this->objDataBinder = QControl::WakeupHelper ($objForm, $this->objDataBinder);
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function HasDataBinder() {
+		return $this->objDataBinder ? true : false;
+	}
+	/**
+	 * Returns the QForm. All QControls implement this.
+	 * @return QForm
+	 */
+	abstract function GetForm();
+}

--- a/includes/base_controls/QFormBase.class.php
+++ b/includes/base_controls/QFormBase.class.php
@@ -602,17 +602,16 @@
 			// End the Response Script
 			exit();	
 		}
-		
-		public function CallDataBinder($strMethodName, QPaginatedControl $objPaginatedControl, $objParentControl = null) {
+
+		/**
+		 * Calls a data binder associated with the form. Does this so data binder can be protected. Mostly for legacy code.
+		 * @param callable $callable
+		 * @param  QControl $objPaginatedControl
+		 * @throws QDataBindException
+		 */
+		public function CallDataBinder($callable, $objPaginatedControl) {
 			try {
-				if (is_array($strMethodName)) {
-					call_user_func($strMethodName, $objPaginatedControl);
-				}
-				elseif ($objParentControl) {
-					$objParentControl->$strMethodName($objPaginatedControl);
-				} else {
-					$this->$strMethodName($objPaginatedControl);
-				}
+				call_user_func($callable, $objPaginatedControl);
 			} catch (QCallerException $objExc) {
 				throw new QDataBindException($objExc);
 			}

--- a/includes/base_controls/QHListItem.class.php
+++ b/includes/base_controls/QHListItem.class.php
@@ -1,0 +1,157 @@
+<?php
+	/**
+	 * QHListItem.class.php contains the QHListItem class
+	 * @package Controls
+	 */
+
+	/**
+	 * Represents an item in a hierarchical item list. Uses the QListItemManager trait to manage the interface for adding
+	 * sub-items.
+	 *
+	 * @package Controls
+	 * @property string $Anchor If set, the anchor text to print in the href= string when drawing as an anchored item.
+	 */
+	class QHListItem extends QListItemBase {
+
+		/** Allows items to have sub items, and manipulate them with the same interface */
+		use QListItemManager;
+
+		///////////////////////////
+		// Private Member Variables
+		///////////////////////////
+		/** @var  string|null if this has an anchor, what to redirect to. Could be javascript or a page. */
+		protected $strAnchor;
+		/** @var  string|null  a custom tag to draw the item with.*/
+		protected $strTag;
+		/** @var  QTagStyler for styling the subtag if needed. */
+		protected $objSubTagStyler;
+
+
+		/////////////////////////
+		// Methods
+		/////////////////////////
+		/**
+		 * Creates a QListItem
+		 *
+		 * @param string  $strName		is the displayed Name or Text of the Item
+		 * @param string|null  $strValue     is any text that represents the value of the ListItem (e.g. maybe a DB Id)
+		 * @param string|null $strAnchor 	is an href anchor that will be associated with item
+		 *
+		 * @throws Exception|QCallerException
+		 */
+		public function __construct($strName, $strValue = null, $strAnchor = null) {
+			parent::__construct ($strName, $strValue);
+			$this->strAnchor = $strAnchor;
+		}
+
+		/**
+		 * Add an item by a QHListItem or a name,value pair
+		 * @param string|QHListItem $mixListItemOrName
+		 * @param string|null $strValue
+		 * @param null|string $strAnchor
+		 */
+		public function AddItem($mixListItemOrName, $strValue = null, $strAnchor = null) {
+			if (gettype($mixListItemOrName) == QType::Object) {
+				$objListItem = QType::Cast($mixListItemOrName, "QHListItem");
+			}
+			else {
+				$objListItem = new QHListItem($mixListItemOrName, $strValue, $strAnchor);
+			}
+
+			$this->AddListItem ($objListItem);
+		}
+
+		/**
+		 * Adds an array of items, or an array of key=>value pairs.
+		 * @param array $objItemArray	An array of QHListItems or key=>val pairs to be sent to contructor.
+		 */
+		public function AddItems($objItemArray) {
+			if (!$objItemArray) return;
+
+			if (!is_object(reset($objItemArray))) {
+				foreach ($objItemArray as $key=>$val) {
+					$this->AddItem ($key, $val);
+				}
+			} else {
+				$this->AddListItems ($objItemArray);
+			}
+		}
+
+		/**
+		 * Returns a QTagStyler for styling the sub tag.
+		 * @return QTagStyler
+		 */
+		public function GetSubTagStyler() {
+			if (!$this->objSubTagStyler) {
+				$this->objSubTagStyler = new QTagStyler();
+			}
+			return $this->objSubTagStyler;
+		}
+
+		/////////////////////////
+		// Public Properties: GET
+		/////////////////////////
+		/**
+		 * PHP magic method
+		 * @param string $strName
+		 *
+		 * @return mixed
+		 * @throws Exception|QCallerException
+		 */
+		public function __get($strName) {
+			switch ($strName) {
+				case "Anchor": return $this->strAnchor;
+				case "Tag": return $this->strTag;
+
+				default:
+					try {
+						return parent::__get($strName);
+					} catch (QCallerException $objExc) {
+						$objExc->IncrementOffset();
+						throw $objExc;
+					}
+			}
+		}
+
+		/////////////////////////
+		// Public Properties: SET
+		/////////////////////////
+		/**
+		 * PHP magic method
+		 * @param string $strName
+		 * @param string $mixValue
+		 *
+		 * @return mixed
+		 * @throws Exception|QCallerException|QInvalidCastException
+		 */
+		public function __set($strName, $mixValue) {
+			switch ($strName) {
+				case "Anchor":
+					try {
+						$this->strAnchor = QType::Cast($mixValue, QType::String);
+						break;
+					} catch (QInvalidCastException $objExc) {
+						$objExc->IncrementOffset();
+						throw $objExc;
+					}
+				case "Tag":
+					try {
+						$this->strTag = QType::Cast($mixValue, QType::String);
+						break;
+					} catch (QInvalidCastException $objExc) {
+						$objExc->IncrementOffset();
+						throw $objExc;
+					}
+
+				default:
+					try {
+						parent::__set($strName, $mixValue);
+					} catch (QCallerException $objExc) {
+						$objExc->IncrementOffset();
+						throw $objExc;
+					}
+					break;
+			}
+		}
+	}
+?>

--- a/includes/base_controls/QHtmlAttributeManagerBase.class.php
+++ b/includes/base_controls/QHtmlAttributeManagerBase.class.php
@@ -66,7 +66,7 @@
  *  converted to dashed notation. Use GetDataAttribute() to retrieve the value of a data attribute.
  * @property boolean $NoWrap sets the CSS white-space  property to nowrap
  * @property boolean $ReadOnly is the "readonly" html attribute (making a textbox "ReadOnly" is  similar to setting the textbox to Enabled
- *  Readonly textboxes are selectedable, and their values get posted. Disabled textboxes are not selectabel and values do not post.
+ *  Readonly textboxes are selectedable, and their values get posted. Disabled textboxes are not selectable and values do not post.
  * @property string $AltText text used for 'alt' attribute in images
  */
 
@@ -393,7 +393,7 @@ class QHtmlAttributeManagerBase extends QBaseClass {
 	/**
 	 * Mark the parent class as modified. The host class must implement this if this functionality is desired.
 	 */
-	protected function MarkAsModified() {}
+	public function MarkAsModified() {}
 
 	/**
 	 * Returns the html for the attributes. Allows the given arrays to override the attributes and styles before

--- a/includes/base_controls/QHtmlAttributeManagerBase.class.php
+++ b/includes/base_controls/QHtmlAttributeManagerBase.class.php
@@ -68,6 +68,8 @@
  * @property boolean $ReadOnly is the "readonly" html attribute (making a textbox "ReadOnly" is  similar to setting the textbox to Enabled
  *  Readonly textboxes are selectedable, and their values get posted. Disabled textboxes are not selectable and values do not post.
  * @property string $AltText text used for 'alt' attribute in images
+ * @property string $OrderedListType type for ordered lists. Expects a QOrderedListType.
+ * @property string $UnorderedListStyle style for unordered lists. Expects a QUnorderedListType.
  */
 
 class QHtmlAttributeManagerBase extends QBaseClass {
@@ -483,6 +485,7 @@ class QHtmlAttributeManagerBase extends QBaseClass {
 			case "VerticalAlign": return $this->GetCssStyle('vertical-align');
 			case "Wrap": throw new Exception ("Wrap is deprecated. Use NoWrap instead");
 			case "NoWrap": return $this->GetCssStyle('white-space') == 'nowrap';
+			case "UnorderedListStyle": return $this->GetCssStyle('list-style-type');
 
 			// Attributes
 			case "CssClass": return $this->GetHtmlAttribute('class');
@@ -492,6 +495,7 @@ class QHtmlAttributeManagerBase extends QBaseClass {
 			case "ToolTip": return $this->GetHtmlAttribute('title');
 			case "ReadOnly": return $this->HasHtmlAttribute('readonly');
 			case "AltText": return $this->HasHtmlAttribute('alt');
+			case "OrderedListType": return $this->GetHtmlAttribute('type');
 
 			default:
 				try {
@@ -755,6 +759,15 @@ class QHtmlAttributeManagerBase extends QBaseClass {
 				$this->SetCssBoxValue('margin', $mixValue);
 				break;
 
+			case "UnorderedListStyle":
+				try {
+					$this->SetCssStyle('list-style-type', QType::Cast($mixValue, QType::String));
+					break;
+				} catch (QInvalidCastException $objExc) {
+					$objExc->IncrementOffset();
+					throw $objExc;
+				}
+
 			// Attributes
 			case "CssClass":
 				try {
@@ -825,6 +838,15 @@ class QHtmlAttributeManagerBase extends QBaseClass {
 			case "AltText":
 				try {
 					$this->SetHtmlAttribute('alt', QType::Cast($mixValue, QType::String));
+					break;
+				} catch (QInvalidCastException $objExc) {
+					$objExc->IncrementOffset();
+					throw $objExc;
+				}
+
+			case "OrderedListType":
+				try {
+					$this->SetHtmlAttribute('type', QType::Cast($mixValue, QType::String));
 					break;
 				} catch (QInvalidCastException $objExc) {
 					$objExc->IncrementOffset();

--- a/includes/base_controls/QHtmlList.class.php
+++ b/includes/base_controls/QHtmlList.class.php
@@ -75,7 +75,7 @@ class QHtmlList extends QListControl {
 	 * @param QListItem $objItem
 	 * @return string
 	 */
-	protected function GetItemHtml ($objItem) {
+	protected function GetItemHtml (QListItem $objItem) {
 		$strHtml = $this->GetItemText($objItem);
 		$strHtml .= "\n";
 		if ($objItem->GetItemCount()) {
@@ -83,7 +83,7 @@ class QHtmlList extends QListControl {
 			foreach ($objItem->GetAllItems() as $objSubItem) {
 				$strSubHtml .= $this->GetItemHtml($objSubItem);
 			}
-			$strHtml .= QHtml::RenderTag($this->strTag, null, $strSubHtml);
+			$strHtml .= QHtml::RenderTag($this->strTag, $this->GetSubTagAttributes($objItem), $strSubHtml);
 		}
 		$objStyler = $this->GetItemStyler($objItem);
 		$strHtml = QHtml::RenderTag($this->strItemTag, $objStyler->RenderHtmlAttributes(), $strHtml);
@@ -91,7 +91,13 @@ class QHtmlList extends QListControl {
 		return $strHtml;
 	}
 
-	protected function GetItemText ($objItem) {
+	/**
+	 * Return the text html of the item.
+	 *
+	 * @param QListItem $objItem
+	 * @return string
+	 */
+	protected function GetItemText (QListItem $objItem) {
 		$strHtml = QApplication::HtmlEntities($objItem->Text);
 
 		if ($strAnchor = $objItem->Anchor) {
@@ -100,7 +106,14 @@ class QHtmlList extends QListControl {
 		return $strHtml;
 	}
 
-	protected function GetItemStyler ($objItem) {
+	/**
+	 * Return the item styler for the given item. Combines the generic item styles found in this class with
+	 * any specific item styles found in the item.
+	 *
+	 * @param QListItem $objItem
+	 * @return QListItemStyle
+	 */
+	protected function GetItemStyler (QListItem $objItem) {
 		if ($this->objItemStyle) {
 			$objStyler = clone $this->objItemStyle;
 		}
@@ -112,6 +125,15 @@ class QHtmlList extends QListControl {
 			$objStyler->Override($objStyle);
 		}
 		return $objStyler;
+	}
+
+	/**
+	 * Return the attributes for the sub tag that wraps the item tags
+	 * @param QListItem $objItem
+	 * @return null|array|string
+	 */
+	protected function GetSubTagAttributes(QListItem $objItem) {
+		return null;
 	}
 
 	/////////////////////////

--- a/includes/base_controls/QListBoxBase.class.php
+++ b/includes/base_controls/QListBoxBase.class.php
@@ -68,10 +68,9 @@
 		 * Returns the HTML-Code for a single Item
 		 * 
 		 * @param QListItem $objItem
-		 * @param integer $intIndex
 		 * @return string resulting HTML
 		 */
-		protected function GetItemHtml($objItem) {
+		protected function GetItemHtml(QListItem $objItem) {
 			// The Default Item Style
 			if ($this->objItemStyle) {
 				$objStyler = clone ($this->objItemStyle);
@@ -84,7 +83,7 @@
 				$objStyler->Override($objStyle);
 			}
 
-			$objStyler->SetHtmlAttribute('value', ($objItem->Empty) ? '' : $objItem->ControlId);
+			$objStyler->SetHtmlAttribute('value', ($objItem->Empty) ? '' : $objItem->Id);
 			if ($objItem->Selected) {
 				$objStyler->SetHtmlAttribute('selected', 'selected');
 			}
@@ -299,10 +298,11 @@
 
 		/**
 		 * Override to insert additional create options pertinent to the control.
-		 * @param $objTable
-		 * @param $objColumn
-		 * @param $strControlVarName
-		 * @return string|void
+		 * @param QCodeGen $objCodeGen
+		 * @param QTable $objTable
+		 * @param QColumn|QManyToManyReference|QReverseReference $objColumn
+		 * @param string $strControlVarName
+		 * @return string
 		 */
 		public static function Codegen_MetaCreateOptions (QCodeGen $objCodeGen, QTable $objTable, $objColumn, $strControlVarName) {
 			$strRet = parent::Codegen_MetaCreateOptions ($objCodeGen, $objTable, $objColumn, $strControlVarName);
@@ -333,4 +333,3 @@ TMPL;
 		}
 
 	}
-?>

--- a/includes/base_controls/QListControl.class.php
+++ b/includes/base_controls/QListControl.class.php
@@ -33,6 +33,23 @@
 		// Methods
 		//////////
 
+		/**
+		 * Return the id. Used by QListItemManager trait.
+		 * @return string
+		 */
+		public function GetId() {
+			return $this->strControlId;
+		}
+
+		/**
+		 * Set the Id. Used by QListItemManager trait.
+		 * @param $strId
+		 */
+		public function SetId($strId) {
+			assert(false); // should never get called on top level item.
+		}
+
+
 		/////////////////////////
 		// Public Properties: GET
 		/////////////////////////

--- a/includes/base_controls/QListItem.class.php
+++ b/includes/base_controls/QListItem.class.php
@@ -45,7 +45,7 @@
 		/** @var  string if this has an anchor, what to redirect to. Could be javascript or a page. */
 		protected $strAnchor;
 		/** @var  string the internal id */
-		protected $strControlId;
+		protected $strId;
 
 
 		/////////////////////////
@@ -94,17 +94,38 @@
 		}
 
 		/**
+		 * Required for QListItemManager trait
+		 */
+		public function MarkAsModified() {}
+
+		/**
+		 * Return the id. Used by trait.
+		 * @return string
+		 */
+		public function GetId() {
+			return $this->strId;
+		}
+
+		/**
+		 * Set the Id. Used by trait.
+		 * @param $strId
+		 */
+		public function SetId($strId) {
+			$this->strId = $strId;
+		}
+
+		/**
 		 * Returns the details of the control as JSON string. This is customized for the JQuery UI autocomplete. If your
 		 * widget requires something else, you will need to subclass and override this.
 		 * @return string
 		 */
 		public function toJsObject() {
-			$strControlId = $this->strValue;
-			if (!$strControlId) {
-				$strControlId = $this->strControlId;
+			$strId = $this->strValue;
+			if (!$strId) {
+				$strId = $this->strId;
 			}
 
-			$a = array('value' => $this->strName, 'id' => $strControlId);
+			$a = array('value' => $this->strName, 'id' => $strId);
 			if ($this->strLabel) {
 				$a['label'] = $this->strLabel;
 			}
@@ -113,7 +134,8 @@
 			}
 			return JavaScriptHelper::toJsObject($a);
 		}
-		
+
+
 
 		/////////////////////////
 		// Public Properties: GET
@@ -135,8 +157,7 @@
 				case "Label": return $this->strLabel;
 				case "Empty": return $this->strValue == null && $this->strName == null;
 				case "Anchor": return $this->strAnchor;
-				case "ControlId": return $this->strControlId;
-				case "Id": return $this->strControlId;
+				case "Id": return $this->strId;
 
 				case "Text":
 					if ($this->strLabel) {
@@ -230,7 +251,7 @@
 				case "Id":
 				case "ControlId":
 					try {
-						$this->strControlId = QType::Cast($mixValue, QType::String);
+						$this->strId = QType::Cast($mixValue, QType::String);
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();

--- a/includes/base_controls/QListItem.class.php
+++ b/includes/base_controls/QListItem.class.php
@@ -11,41 +11,21 @@
 	 * for the options in each item. Note that not all the options are used by every control, and we don't do any drawing here.
 	 *
 	 * @package Controls
-	 * @property string         $Name      Usually what gets displayed. Can be overridden by the Label attribute in certain situations.
-	 * @property string         $Value     is any text that represents the value of the item (e.g. maybe a DB Id)
 	 * @property boolean        $Selected  is a boolean of whether or not this item is selected or not (do only! use during initialization, otherwise this should be set by the {@link QListControl}!)
 	 * @property string         $ItemGroup is the group (if any) in which the Item should be displayed
-	 * @property QListItemStyle $ItemStyle Custom HTML attributes for this particular item.
-	 * @property string         $Text      synonym of Name. Used to store longer text with the item.
 	 * @property string         $Label     is optional text to display instead of the Name for certain controls.
-	 * @property-read boolean   $Empty     true when both $Name and $Value are null, in which case this item will be rendered with an empty value in the list control
-	 * @property string $Anchor If set, the anchor text to print in the href= string when drawing as an anchored item.
-	 * @property string $ControlId If set, the id associated with the item.
-	 * @property string $Id 	Synonym of ControlId.
 	 */
-	class QListItem extends QBaseClass {
-
-		use QListItemManager;
+	class QListItem extends QListItemBase {
 
 		///////////////////////////
 		// Private Member Variables
 		///////////////////////////
-		/** @var null|string Name of the Item */
-		protected $strName = null;
-		/** @var null|string Value of the Item */
-		protected $strValue = null;
 		/** @var bool Is the item selected? */
 		protected $blnSelected = false;
 		/** @var null|string Group to which the item belongs, if control supports groups. */
 		protected $strItemGroup = null;
-		/** @var QListItemStyle Custom attributes of the list item */
-		protected $objItemStyle;
 		/** @var string Label text for the item. */
 		protected $strLabel = null;
-		/** @var  string if this has an anchor, what to redirect to. Could be javascript or a page. */
-		protected $strAnchor;
-		/** @var  string the internal id */
-		protected $strId;
 
 
 		/////////////////////////
@@ -66,8 +46,7 @@
 		 * @return QListItem
 		 */
 		public function __construct($strName, $strValue = null, $blnSelected = false, $strItemGroup = null, $mixOverrideParameters = null) {
-			$this->strName = $strName;
-			$this->strValue = $strValue;
+			parent::__construct ($strName, $strValue);
 			$this->blnSelected = $blnSelected;
 			$this->strItemGroup = $strItemGroup;
 
@@ -77,41 +56,8 @@
 				throw new QCallerException ("Please provide either a string, or an array, but not multiple parameters");
 			}
 			if ($mixOverrideParameters) {
-				$this->objItemStyle = new QListItemStyle();
-				$this->objItemStyle->OverrideAttributes($mixOverrideParameters);
+				$this->GetStyle()->OverrideAttributes($mixOverrideParameters);
 			}
-		}
-
-		/**
-		 * Returns the css style of the list item
-		 * @deprecated
-		 *
-		 * @return string
-		 */
-		public function GetAttributes() {
-			$strToReturn = $this->objItemStyle->GetAttributes();
-			return $strToReturn;
-		}
-
-		/**
-		 * Required for QListItemManager trait
-		 */
-		public function MarkAsModified() {}
-
-		/**
-		 * Return the id. Used by trait.
-		 * @return string
-		 */
-		public function GetId() {
-			return $this->strId;
-		}
-
-		/**
-		 * Set the Id. Used by trait.
-		 * @param $strId
-		 */
-		public function SetId($strId) {
-			$this->strId = $strId;
 		}
 
 		/**
@@ -149,24 +95,9 @@
 		 */
 		public function __get($strName) {
 			switch ($strName) {
-				case "Name": return $this->strName;
-				case "Value": return $this->strValue;
 				case "Selected": return $this->blnSelected;
 				case "ItemGroup": return $this->strItemGroup;
-				case "ItemStyle": return $this->objItemStyle;
 				case "Label": return $this->strLabel;
-				case "Empty": return $this->strValue == null && $this->strName == null;
-				case "Anchor": return $this->strAnchor;
-				case "Id": return $this->strId;
-
-				case "Text":
-					if ($this->strLabel) {
-						return $this->strLabel;
-					}
-					else {
-						return $this->strName;
-					}
-
 
 				default:
 					try {
@@ -191,23 +122,6 @@
 		 */
 		public function __set($strName, $mixValue) {
 			switch ($strName) {
-				case "Text":
-				case "Name":
-					try {
-						$this->strName = QType::Cast($mixValue, QType::String);
-						break;
-					} catch (QInvalidCastException $objExc) {
-						$objExc->IncrementOffset();
-						throw $objExc;
-					}
-				case "Value":
-					try {
-						$this->strValue = QType::Cast($mixValue, QType::String);
-						break;
-					} catch (QInvalidCastException $objExc) {
-						$objExc->IncrementOffset();
-						throw $objExc;
-					}				
 				case "Selected":
 					try {
 						$this->blnSelected = QType::Cast($mixValue, QType::Boolean);
@@ -224,34 +138,9 @@
 						$objExc->IncrementOffset();
 						throw $objExc;
 					}
-				case "ItemStyle":
-					try {
-						$this->objItemStyle = QType::Cast($mixValue, "QListItemStyle");
-						break;
-					} catch (QInvalidCastException $objExc) {
-						$objExc->IncrementOffset();
-						throw $objExc;
-					}
 				case "Label":
 					try {
 						$this->strLabel = QType::Cast($mixValue, QType::String);
-						break;
-					} catch (QInvalidCastException $objExc) {
-						$objExc->IncrementOffset();
-						throw $objExc;
-					}
-				case "Anchor":
-					try {
-						$this->strAnchor = QType::Cast($mixValue, QType::String);
-						break;
-					} catch (QInvalidCastException $objExc) {
-						$objExc->IncrementOffset();
-						throw $objExc;
-					}
-				case "Id":
-				case "ControlId":
-					try {
-						$this->strId = QType::Cast($mixValue, QType::String);
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -268,4 +157,3 @@
 			}
 		}
 	}
-?>

--- a/includes/base_controls/QListItem.class.php
+++ b/includes/base_controls/QListItem.class.php
@@ -44,8 +44,6 @@
 		protected $strLabel = null;
 		/** @var  string if this has an anchor, what to redirect to. Could be javascript or a page. */
 		protected $strAnchor;
-		/** @var QListItem[] and array of subitems if this is a recursive item.  */
-		protected $objSubItems;
 		/** @var  string the internal id */
 		protected $strControlId;
 

--- a/includes/base_controls/QListItem.class.php
+++ b/includes/base_controls/QListItem.class.php
@@ -5,18 +5,28 @@
 	 */
 
 	/**
-	 * Utilized by the {@link QListControl} class which contains a private array of ListItems.
+	 * Utilized by the {@link QListControl} class which contains a private array of ListItems. Originally these
+	 * represented items in a select list, but now represent items in any kind of control that has repetitive items
+	 * in it. This includes list controls, menus, drop-downs, and hierarchical lists. This is a general purpose container
+	 * for the options in each item. Note that not all the options are used by every control, and we don't do any drawing here.
 	 *
 	 * @package Controls
-	 * @property string         $Name      is what gets displayed
-	 * @property string         $Value     is any text that represents the value of the ListItem (e.g. maybe a DB Id)
+	 * @property string         $Name      Usually what gets displayed. Can be overridden by the Label attribute in certain situations.
+	 * @property string         $Value     is any text that represents the value of the item (e.g. maybe a DB Id)
 	 * @property boolean        $Selected  is a boolean of whether or not this item is selected or not (do only! use during initialization, otherwise this should be set by the {@link QListControl}!)
 	 * @property string         $ItemGroup is the group (if any) in which the Item should be displayed
-	 * @property QListItemStyle $ItemStyle is the QListItemStyle in which the Item should be rendered
-	 * @property string         $Label     is optional text to display in the drop down menu of a QAutocomplete instead of the Name. The Name will still be what gets filled in to the text box.
+	 * @property QListItemStyle $ItemStyle Custom HTML attributes for this particular item.
+	 * @property string         $Text      synonym of Name. Used to store longer text with the item.
+	 * @property string         $Label     is optional text to display instead of the Name for certain controls.
 	 * @property-read boolean   $Empty     true when both $Name and $Value are null, in which case this item will be rendered with an empty value in the list control
+	 * @property string $Anchor If set, the anchor text to print in the href= string when drawing as an anchored item.
+	 * @property string $ControlId If set, the id associated with the item.
+	 * @property string $Id 	Synonym of ControlId.
 	 */
 	class QListItem extends QBaseClass {
+
+		use QListItemManager;
+
 		///////////////////////////
 		// Private Member Variables
 		///////////////////////////
@@ -26,12 +36,19 @@
 		protected $strValue = null;
 		/** @var bool Is the item selected? */
 		protected $blnSelected = false;
-		/** @var null|string Group to which the item belongs */
+		/** @var null|string Group to which the item belongs, if control supports groups. */
 		protected $strItemGroup = null;
-		/** @var QListItemStyle Inline style of the item */
+		/** @var QListItemStyle Custom attributes of the list item */
 		protected $objItemStyle;
-		/** @var string Label text for the item */
+		/** @var string Label text for the item. */
 		protected $strLabel = null;
+		/** @var  string if this has an anchor, what to redirect to. Could be javascript or a page. */
+		protected $strAnchor;
+		/** @var QListItem[] and array of subitems if this is a recursive item.  */
+		protected $objSubItems;
+		/** @var  string the internal id */
+		protected $strControlId;
+
 
 		/////////////////////////
 		// Methods
@@ -43,14 +60,14 @@
 		 * @param string  $strValue     is any text that represents the value of the ListItem (e.g. maybe a DB Id)
 		 * @param boolean $blnSelected  is a boolean of whether or not this item is selected or not (optional)
 		 * @param string  $strItemGroup is the group (if any) in which the Item should be displayed
-		 * @param array   $strOverrideParameters
+		 * @param array|string   $mixOverrideParameters
 		 *                              allows you to override item styles.  It is either a string formatted as Property=Value
 		 *                              or an array of the format array(property => value)
 		 *
 		 * @throws Exception|QCallerException
 		 * @return QListItem
 		 */
-		public function __construct($strName, $strValue, $blnSelected = false, $strItemGroup = null, $strOverrideParameters = null) {
+		public function __construct($strName, $strValue = null, $blnSelected = false, $strItemGroup = null, $mixOverrideParameters = null) {
 			$this->strName = $strName;
 			$this->strValue = $strValue;
 			$this->blnSelected = $blnSelected;
@@ -59,26 +76,17 @@
 			// Override parameters get applied here
 			$strOverrideArray = func_get_args();
 			if (count($strOverrideArray) > 4)	{
-				try {
-					$strOverrideArray = array_reverse($strOverrideArray);
-					array_pop($strOverrideArray);
-					array_pop($strOverrideArray);
-					array_pop($strOverrideArray);
-					array_pop($strOverrideArray);
-					$strOverrideArray = array_reverse($strOverrideArray);
-					$this->objItemStyle = new QListItemStyle();
-					$this->objItemStyle->OverrideAttributes($strOverrideArray);
-				} catch (QCallerException $objExc) {
-					$objExc->IncrementOffset();
-					throw $objExc;
-				}
+				throw new QCallerException ("Please provide either a string, or an array, but not multiple parameters");
+			}
+			if ($mixOverrideParameters) {
+				$this->objItemStyle = new QListItemStyle();
+				$this->objItemStyle->OverrideAttributes($mixOverrideParameters);
 			}
 		}
 
 		/**
 		 * Returns the css style of the list item
-		 * @param bool $blnIncludeCustom [Currently Unused]
-		 * @param bool $blnIncludeAction [Currently Unused]
+		 * @deprecated
 		 *
 		 * @return string
 		 */
@@ -88,11 +96,17 @@
 		}
 
 		/**
-		 * Returns the details of the control as JSON string
+		 * Returns the details of the control as JSON string. This is customized for the JQuery UI autocomplete. If your
+		 * widget requires something else, you will need to subclass and override this.
 		 * @return string
 		 */
 		public function toJsObject() {
-			$a = array('value' => $this->strName, 'id' => $this->strValue);
+			$strControlId = $this->strValue;
+			if (!$strControlId) {
+				$strControlId = $this->strControlId;
+			}
+
+			$a = array('value' => $this->strName, 'id' => $strControlId);
 			if ($this->strLabel) {
 				$a['label'] = $this->strLabel;
 			}
@@ -122,6 +136,18 @@
 				case "ItemStyle": return $this->objItemStyle;
 				case "Label": return $this->strLabel;
 				case "Empty": return $this->strValue == null && $this->strName == null;
+				case "Anchor": return $this->strAnchor;
+				case "ControlId": return $this->strControlId;
+				case "Id": return $this->strControlId;
+
+				case "Text":
+					if ($this->strLabel) {
+						return $this->strLabel;
+					}
+					else {
+						return $this->strName;
+					}
+
 
 				default:
 					try {
@@ -146,6 +172,7 @@
 		 */
 		public function __set($strName, $mixValue) {
 			switch ($strName) {
+				case "Text":
 				case "Name":
 					try {
 						$this->strName = QType::Cast($mixValue, QType::String);
@@ -194,7 +221,23 @@
 						$objExc->IncrementOffset();
 						throw $objExc;
 					}
-										
+				case "Anchor":
+					try {
+						$this->strAnchor = QType::Cast($mixValue, QType::String);
+						break;
+					} catch (QInvalidCastException $objExc) {
+						$objExc->IncrementOffset();
+						throw $objExc;
+					}
+				case "Id":
+				case "ControlId":
+					try {
+						$this->strControlId = QType::Cast($mixValue, QType::String);
+						break;
+					} catch (QInvalidCastException $objExc) {
+						$objExc->IncrementOffset();
+						throw $objExc;
+					}
 				default:
 					try {
 						parent::__set($strName, $mixValue);

--- a/includes/base_controls/QListItemBase.class.php
+++ b/includes/base_controls/QListItemBase.class.php
@@ -1,0 +1,177 @@
+<?php
+	/**
+	 * QListItemBase.class.php contains the QListItemBase class
+	 * @package Controls
+	 */
+
+	/**
+	 * This base class represents an item in some kind of html item list. There are many types of possible lists, including
+	 * checklists and hierarchical lists. This is the core functionality common to all of them.
+	 *
+	 * @package Controls
+	 * @property string         $Name      Usually what gets displayed. Can be overridden by the Label attribute in certain situations.
+	 * @property string         $Value     is any text that represents the value of the item (e.g. maybe a DB Id)
+	 * @property-read boolean   $Empty     true when both $Name and $Value are null, in which case this item will be rendered with an empty value in the list control
+	 * @property QListItemStyle $ItemStyle Custom HTML attributes for this particular item.
+	 * @property string         $Text      synonym of Name. Used to store longer text with the item.
+	 * @property string $Id 	A place to save an id for the item. It is up to the corresponding list class to use this in the object.
+	 */
+	class QListItemBase extends QBaseClass {
+		///////////////////////////
+		// Private Member Variables
+		///////////////////////////
+		/** @var null|string Name of the Item */
+		protected $strName = null;
+		/** @var null|string Value of the Item */
+		protected $strValue = null;
+		/** @var QListItemStyle Custom attributes of the list item */
+		protected $objItemStyle;
+		/** @var  string the internal id */
+		protected $strId;
+
+
+		/////////////////////////
+		// Methods
+		/////////////////////////
+		/**
+		 * Creates a QListItem
+		 *
+		 * @param string  $strName      is the displayed Name or Text of the Item
+		 * @param string|null  $strValue     is any text that represents the value of the ListItem (e.g. maybe a DB Id)
+		 * @param null|QListItemStyle  $objItemStyle     is the item style. If provided here, it is referenced and shared with other items.
+		 *
+		 * @throws Exception|QCallerException
+		 */
+		public function __construct($strName, $strValue = null, $objItemStyle = null) {
+			$this->strName = $strName;
+			$this->strValue = $strValue;
+			$this->objItemStyle = $objItemStyle;
+		}
+
+		public function GetStyle() {
+			if (!$this->objItemStyle) {
+				$this->objItemStyle = new QListItemStyle();
+			}
+			return $this->objItemStyle;
+		}
+
+		/**
+		 * Returns the css style of the list item
+		 * @deprecated
+		 *
+		 * @return string
+		 */
+		public function GetAttributes() {
+			$strToReturn = $this->GetStyle()->GetAttributes();
+			return $strToReturn;
+		}
+
+		/**
+		 * Stub functions required for QListItemManager trait support
+		 */
+		public function MarkAsModified() {}
+		public function Reindex() {}
+		public function FindItem($strId) {return null;}
+
+		/**
+		 * Return the id. Used by trait.
+		 * @return string
+		 */
+		public function GetId() {
+			return $this->strId;
+		}
+
+		/**
+		 * Set the Id. Used by trait.
+		 * @param $strId
+		 */
+		public function SetId($strId) {
+			$this->strId = $strId;
+		}
+
+		/////////////////////////
+		// Public Properties: GET
+		/////////////////////////
+		/**
+		 * PHP magic method
+		 * @param string $strName
+		 *
+		 * @return mixed
+		 * @throws Exception|QCallerException
+		 */
+		public function __get($strName) {
+			switch ($strName) {
+				case "Text":
+				case "Name": return $this->strName;
+				case "Value": return $this->strValue;
+				case "ItemStyle": return $this->objItemStyle;
+				case "Empty": return $this->strValue == null && $this->strName == null;
+				case "Id": return $this->strId;
+
+				default:
+					try {
+						return parent::__get($strName);
+					} catch (QCallerException $objExc) {
+						$objExc->IncrementOffset();
+						throw $objExc;
+					}
+			}
+		}
+
+		/////////////////////////
+		// Public Properties: SET
+		/////////////////////////
+		/**
+		 * PHP magic method
+		 * @param string $strName
+		 * @param string $mixValue
+		 *
+		 * @return mixed
+		 * @throws Exception|QCallerException|QInvalidCastException
+		 */
+		public function __set($strName, $mixValue) {
+			switch ($strName) {
+				case "Text":
+				case "Name":
+					try {
+						$this->strName = QType::Cast($mixValue, QType::String);
+						break;
+					} catch (QInvalidCastException $objExc) {
+						$objExc->IncrementOffset();
+						throw $objExc;
+					}
+				case "Value":
+					try {
+						$this->strValue = QType::Cast($mixValue, QType::String);
+						break;
+					} catch (QInvalidCastException $objExc) {
+						$objExc->IncrementOffset();
+						throw $objExc;
+					}				
+				case "ItemStyle":
+					try {
+						$this->objItemStyle = QType::Cast($mixValue, "QListItemStyle");
+						break;
+					} catch (QInvalidCastException $objExc) {
+						$objExc->IncrementOffset();
+						throw $objExc;
+					}
+				case "Id":
+					try {
+						$this->strId = QType::Cast($mixValue, QType::String);
+						break;
+					} catch (QInvalidCastException $objExc) {
+						$objExc->IncrementOffset();
+						throw $objExc;
+					}
+				default:
+					try {
+						parent::__set($strName, $mixValue);
+					} catch (QCallerException $objExc) {
+						$objExc->IncrementOffset();
+						throw $objExc;
+					}
+					break;
+			}
+		}
+	}

--- a/includes/base_controls/QListItemManager.trait.php
+++ b/includes/base_controls/QListItemManager.trait.php
@@ -30,8 +30,8 @@
 				$objListItem = new QListItem($mixListItemOrName, $strValue, $blnSelected, $strItemGroup);
 			}
 
-			if ($strControlId = $objListItem->ControlId) {
-				$objListItem->ControlId = $this->ControlId . '_' . count($this->objListItemArray);	// auto assign the id based on parent id
+			if ($strControlId = $this->ControlId) {
+				$objListItem->ControlId = $strControlId . '_' . count($this->objListItemArray);	// auto assign the id based on parent id
 				$objListItem->Reindex();
 			}
 			$this->objListItemArray[] = $objListItem;

--- a/includes/base_controls/QListItemManager.trait.php
+++ b/includes/base_controls/QListItemManager.trait.php
@@ -1,0 +1,398 @@
+<?php
+	/**
+	 * QListItemManagerager.trait.php contains the QListItemManager trait
+	 * @package Controls
+	 */
+
+	/**
+	 * Since QListItems can be recursive, then logically both a QListControl, and a QListItem manages a collection of
+	 * QListItems. To prevent duplication of code, this trait is used by both to do that basic management of the
+	 * item list itself.
+	 *
+	 * @package Controls
+	 */
+	trait QListItemManager {
+		///////////////////////////
+		// Private Member Variables
+		///////////////////////////
+		/** @var QListItem[] an array of subitems if this is a recursive item.  */
+		protected $objListItemArray;
+
+		public function AddItem($mixListItemOrName, $strValue = null, $blnSelected = null, $strItemGroup = null, $mixOverrideParameters = null) {
+			if (gettype($mixListItemOrName) == QType::Object) {
+				$objListItem = QType::Cast($mixListItemOrName, "QListItem");
+			}
+			elseif ($mixOverrideParameters) {
+				// The OverrideParameters can only be included if they are not null, because OverrideAttributes in QBaseClass can't except a NULL Value
+				$objListItem = new QListItem($mixListItemOrName, $strValue, $blnSelected, $strItemGroup, $mixOverrideParameters);
+			}
+			else {
+				$objListItem = new QListItem($mixListItemOrName, $strValue, $blnSelected, $strItemGroup);
+			}
+
+			if ($strControlId = $objListItem->ControlId) {
+				$objListItem->ControlId = $this->ControlId . '_' . count($this->objListItemArray);	// auto assign the id based on parent id
+				$objListItem->Reindex();
+			}
+			$this->objListItemArray[] = $objListItem;
+			$this->_MarkAsModified();
+		}
+
+		/**
+		 * Allows you to add a ListItem at a certain index
+		 * Unlike AddItem, this will insert the ListItem at whatever index is passed to the function.  Additionally,
+		 * only a ListItem object can be passed (as opposed to an object or strings)
+		 *
+		 * @param integer   $intIndex    index at which the item should be inserted
+		 * @param QListItem $objListItem the ListItem which shall be inserted
+		 *
+		 * @throws QIndexOutOfRangeException
+		 * @throws Exception|QInvalidCastException
+		 */
+		public function AddItemAt($intIndex, QListItem $objListItem) {
+			try {
+				$intIndex = QType::Cast($intIndex, QType::Integer);
+			} catch (QInvalidCastException $objExc) {
+				$objExc->IncrementOffset();
+				throw $objExc;
+			}
+			if ($intIndex >= 0 &&
+				(!$this->objListItemArray && $intIndex == 0 ||
+					$intIndex <= count($this->objListItemArray))) {
+				for ($intCount = count($this->objListItemArray); $intCount > $intIndex; $intCount--) {
+					$this->objListItemArray[$intCount] = $this->objListItemArray[$intCount - 1];
+				}
+			} else {
+				throw new QIndexOutOfRangeException($intIndex, "AddItemAt()");
+			}
+
+			$this->objListItemArray[$intIndex] = $objListItem;
+			$this->Reindex();
+		}
+
+		/**
+		 * Reindex the ids of the items based on the current item.
+		 */
+		public function Reindex() {
+			if ($this->ControlId && $this->objListItemArray) for ($i = 0; $i < $this->GetItemCount(); $i++) {
+				$this->objListItemArray[$i]->ControlId = $this->ControlId . '_' . $i;	// assign the id based on parent id
+				$this->objListItemArray[$i]->Reindex();
+			}
+		}
+
+		/**
+		 * Stub function. If the object this is mixed in with is a control, then the control will override and implement.
+		 */
+		private function _MarkAsModified() {
+			if (method_exists($this, 'MarkAsModified')) {
+				$this->MarkAsModified();	// No current way around this. We are calling an unknown function, which makes this trait not self validated.
+			}
+		}
+
+
+		/**
+		 * Adds an array of items, or an array of key=>value pairs. Convenient for adding a list from a type table.
+		 * When passing key=>val pairs, mixSelectedValues can be an array, or just a single value to compare against to indicate what is selected.
+		 *
+		 * @param array  $mixItemArray          Array of QListItems or key=>val pairs.
+		 * @param mixed  $mixSelectedValues     Array of selected values, or value of one selection
+		 * @param string $strItemGroup          allows you to apply grouping (<optgroup> tag)
+		 * @param string $mixOverrideParameters OverrideParameters for ListItemStyle
+		 *
+		 * @throws Exception|QInvalidCastException
+		 */
+		public function AddItems(array $mixItemArray, $mixSelectedValues = null, $strItemGroup = null, $mixOverrideParameters = null) {
+			try {
+				$mixItemArray = QType::Cast($mixItemArray, QType::ArrayType);
+			} catch (QInvalidCastException $objExc) {
+				$objExc->IncrementOffset();
+				throw $objExc;
+			}
+
+			foreach ($mixItemArray as $val => $item) {
+				if ($val === '') {
+					$val = null; // these are equivalent when specified as a key of an array
+				}
+				if ($mixSelectedValues && is_array($mixSelectedValues)) {
+					$blnSelected = in_array($val, $mixSelectedValues);
+				} else {
+					$blnSelected = ($val === $mixSelectedValues);	// differentiate between null and 0 values
+				}
+				$this->AddItem($item, $val, $blnSelected, $strItemGroup, $mixOverrideParameters);
+			};
+			$this->Reindex();
+			$this->_MarkAsModified();
+		}
+
+		/**
+		 * Retrieve the ListItem at the specified index location
+		 *
+		 * @param integer $intIndex
+		 *
+		 * @throws QIndexOutOfRangeException
+		 * @throws Exception|QInvalidCastException
+		 * @return QListItem
+		 */
+		public function GetItem($intIndex) {
+			try {
+				$intIndex = QType::Cast($intIndex, QType::Integer);
+			} catch (QInvalidCastException $objExc) {
+				$objExc->IncrementOffset();
+				throw $objExc;
+			}
+			if (($intIndex < 0) ||
+				($intIndex >= count($this->objListItemArray)))
+				throw new QIndexOutOfRangeException($intIndex, "GetItem()");
+
+			return $this->objListItemArray[$intIndex];
+		}
+
+		/**
+		 * This will return an array of ALL the QListItems associated with this QListControl.
+		 * Please note that while each individual item can be altered, altering the array, itself,
+		 * will not affect any change on the QListControl.  So existing QListItems may be modified,
+		 * but to add / remove items from the QListControl, you should use AddItem() and RemoveItem().
+		 * @return QListItem[]
+		 */
+		public function GetAllItems() {
+			return $this->objListItemArray;
+		}
+
+		/**
+		 * Removes all the items in objListItemArray
+		 */
+		public function RemoveAllItems() {
+			$this->_MarkAsModified();
+			$this->objListItemArray = null;
+		}
+
+		/**
+		 * Removes a ListItem at the specified index location
+		 *
+		 * @param integer $intIndex
+		 *
+		 * @throws QIndexOutOfRangeException
+		 * @throws Exception|QInvalidCastException
+		 */
+		public function RemoveItem($intIndex) {
+			try {
+				$intIndex = QType::Cast($intIndex, QType::Integer);
+			} catch (QInvalidCastException $objExc) {
+				$objExc->IncrementOffset();
+				throw $objExc;
+			}
+			if (($intIndex < 0) ||
+				($intIndex > (count($this->objListItemArray) - 1)))
+				throw new QIndexOutOfRangeException($intIndex, "RemoveItem()");
+			for ($intCount = $intIndex; $intCount < count($this->objListItemArray) - 1; $intCount++) {
+				$this->objListItemArray[$intCount] = $this->objListItemArray[$intCount + 1];
+			}
+
+			$this->objListItemArray[$intCount] = null;
+			unset($this->objListItemArray[$intCount]);
+			$this->_MarkAsModified();
+			$this->Reindex();
+		}
+
+		/**
+		 * Replaces a QListItem at $intIndex. This combines the RemoveItem() and AddItemAt() operations.
+		 *
+		 * @param integer   $intIndex
+		 * @param QListItem $objListItem
+		 *
+		 * @throws Exception|QInvalidCastException
+		 */
+		public function ReplaceItem($intIndex, QListItem $objListItem) {
+			try {
+				$intIndex = QType::Cast($intIndex, QType::Integer);
+			} catch (QInvalidCastException $objExc) {
+				$objExc->IncrementOffset();
+				throw $objExc;
+			}
+			$objListItem->ControlId = $this->ControlId . '_' . $intIndex;
+			$this->objListItemArray[$intIndex] = $objListItem;
+			$objListItem->Reindex();
+			$this->_MarkAsModified();
+		}
+
+		/**
+		 * Finds the item by id recursively. Makes use of the fact that we maintain the ids in order to efficiently
+		 * find the item.
+		 *
+		 * @param string $strId If this is a sub-item, it will be an id fragment
+		 * @return null|QListItem
+		 */
+		public function FindItem($strId) {
+			$objFoundItem = null;
+			$a = explode ('_', $strId, 3);
+			if (isset($a[1]) &&
+					$this->objListItemArray &&	// just in case
+					$a[1] < count ($this->objListItemArray)) {	// just in case
+				$objFoundItem = $this->objListItemArray[$a[1]];
+			}
+			if (isset($a[2])) {
+				$objFoundItem = $objFoundItem->FindItem ($a[1] . '_' . $a[2]);
+			}
+
+			return $objFoundItem;
+		}
+
+		public function GetItemCount($blnRecursive = false) {
+			$count = 0;
+			if ($this->objListItemArray) {
+				$count = count($this->objListItemArray);
+				if ($blnRecursive) {
+					foreach ($this->objListItemArray as $objListItem) {
+						$count += $objListItem->GetItemCount(true);
+					}
+				}
+			}
+			return $count;
+		}
+
+		/**
+		 * Recursively unselects all the items and subitems in the list.
+		 *
+		 * @param bool $blnMarkAsModified
+		 */
+		public function UnselectAllItems($blnMarkAsModified = true) {
+			$intCount = $this->GetItemCount();
+			for ($intIndex = 0; $intIndex < $intCount; $intIndex++) {
+				$objItem = $this->GetItem($intIndex);
+				$objItem->Selected = false;
+				if ($objItem->GetItemCount()) {
+					$objItem->UnselectAllItems(false);
+				}
+			}
+			if ($blnMarkAsModified) {
+				$this->_MarkAsModified();
+			}
+		}
+
+
+		/**
+		 * Selects the given items by Id, and unselects items that are not in the list.
+		 * @param string[] $strIdArray
+		 * @param bool $blnMarkAsModified
+		 */
+		public function SetSelectedItemsById(array $strIdArray, $blnMarkAsModified = true) {
+			$intCount = $this->GetItemCount();
+			for ($intIndex = 0; $intIndex < $intCount; $intIndex++) {
+				$objItem = $this->GetItem($intIndex);
+				$strId = $objItem->ControlId;
+				$objItem->Selected = in_array($strId, $strIdArray);
+				if ($objItem->GetItemCount()) {
+					$objItem->SetSelectedItemsById($strIdArray, false);
+				}
+			}
+			if ($blnMarkAsModified) {
+				$this->_MarkAsModified();
+			}
+		}
+
+		/**
+		 * Set the selected item by index. This can only set top level items. Lower level items are untouched.
+		 * @param integer[] $intIndexArray
+		 * @param bool $blnMarkAsModified
+		 */
+		public function SetSelectedItemsByIndex(array $intIndexArray, $blnMarkAsModified = true) {
+			$intCount = $this->GetItemCount();
+			for ($intIndex = 0; $intIndex < $intCount; $intIndex++) {
+				$objItem = $this->GetItem($intIndex);
+				$objItem->Selected = in_array($intIndex, $intIndexArray);
+			}
+			if ($blnMarkAsModified) {
+				$this->_MarkAsModified();
+			}
+		}
+
+		/**
+		 * Set the selected items by value. We equate nulls and empty strings, but must be careful not to equate
+		 * those with a zero.
+		 *
+		 * @param array $mixValueArray
+		 * @param bool $blnMarkAsModified
+		 */
+		public function SetSelectedItemsByValue(array $mixValueArray, $blnMarkAsModified = true) {
+			$intCount = $this->GetItemCount();
+
+			for ($intIndex = 0; $intIndex < $intCount; $intIndex++) {
+				$objItem = $this->GetItem($intIndex);
+				$mixCurVal = $objItem->Value;
+				$blnSelected = false;
+				foreach ($mixValueArray as $mixValue) {
+					if (!$mixValue) {
+						if ($mixValue === null || $mixValue === '') {
+							if ($mixCurVal === null || $mixCurVal === '') {
+								$blnSelected = true;
+							}
+						} else {
+							if (!($mixCurVal === null || $mixCurVal === '')) {
+								$$blnSelected = true;
+							}
+						}
+					}
+					elseif ($mixCurVal == $mixValue) {
+						$blnSelected = true;
+					}
+				}
+				$objItem->Selected = $blnSelected;
+			}
+			if ($blnMarkAsModified) {
+				$this->_MarkAsModified();
+			}
+		}
+
+
+		/**
+		 * Set the selected items by name.
+		 * @param string[] $strNameArray
+		 * @param bool $blnMarkAsModified
+		 */
+		public function SetSelectedItemsByName(array $strNameArray, $blnMarkAsModified = true) {
+			$intCount = $this->GetItemCount();
+			for ($intIndex = 0; $intIndex < $intCount; $intIndex++) {
+				$objItem = $this->GetItem($intIndex);
+				$strName = $objItem->Name;
+				$objItem->Selected = in_array($strName, $strNameArray);
+				if ($objItem->GetItemCount()) {
+					$objItem->SetSelectedItemsByName($strNameArray, false);
+				}
+			}
+			if ($blnMarkAsModified) {
+				$this->_MarkAsModified();
+			}
+		}
+
+
+		public function GetFirstSelectedItem() {
+			$intCount = $this->GetItemCount();
+			for ($intIndex = 0; $intIndex < $intCount; $intIndex++) {
+				$objItem = $this->GetItem($intIndex);
+				if ($objItem->Selected) {
+					return $objItem;
+				}
+				if ($objItem2 = $objItem->GetFirstSelectedItem()) {
+					return $objItem2;
+				}
+			}
+			return null;
+		}
+
+		public function GetSelectedItems() {
+			$aResult = array();
+			$intCount = $this->GetItemCount();
+			for ($intIndex = 0; $intIndex < $intCount; $intIndex++) {
+				$objItem = $this->GetItem($intIndex);
+				if ($objItem->Selected) {
+					$aResult[] = $objItem;
+				}
+				if ($objItems = $objItem->GetSelectedItems()) {
+					$aResult = array_merge ($aResult, $objItems);
+				}
+			}
+			return $aResult;
+		}
+
+
+	}

--- a/includes/base_controls/QListItemManager.trait.php
+++ b/includes/base_controls/QListItemManager.trait.php
@@ -30,12 +30,12 @@
 				$objListItem = new QListItem($mixListItemOrName, $strValue, $blnSelected, $strItemGroup);
 			}
 
-			if ($strControlId = $this->ControlId) {
-				$objListItem->ControlId = $strControlId . '_' . count($this->objListItemArray);	// auto assign the id based on parent id
+			if ($strControlId = $this->GetId()) {
+				$objListItem->SetId($strControlId . '_' . count($this->objListItemArray));	// auto assign the id based on parent id
 				$objListItem->Reindex();
 			}
 			$this->objListItemArray[] = $objListItem;
-			$this->_MarkAsModified();
+			$this->MarkAsModified();
 		}
 
 		/**
@@ -74,21 +74,28 @@
 		 * Reindex the ids of the items based on the current item.
 		 */
 		public function Reindex() {
-			if ($this->ControlId && $this->objListItemArray) for ($i = 0; $i < $this->GetItemCount(); $i++) {
-				$this->objListItemArray[$i]->ControlId = $this->ControlId . '_' . $i;	// assign the id based on parent id
+			if ($this->GetId() && $this->objListItemArray) for ($i = 0; $i < $this->GetItemCount(); $i++) {
+				$this->objListItemArray[$i]->SetId($this->GetId() . '_' . $i);	// assign the id based on parent id
 				$this->objListItemArray[$i]->Reindex();
 			}
 		}
 
 		/**
-		 * Stub function. If the object this is mixed in with is a control, then the control will override and implement.
+		 * Stub function. The including function needs to implement this.
 		 */
-		private function _MarkAsModified() {
-			if (method_exists($this, 'MarkAsModified')) {
-				$this->MarkAsModified();	// No current way around this. We are calling an unknown function, which makes this trait not self validated.
-			}
-		}
+		abstract public function MarkAsModified();
 
+		/**
+		 * Returns the id of the item, however the item stores it.
+		 * @return string
+		 */
+		abstract public function GetId();
+
+		/**
+		 * Sets the id of the object
+		 * @param string
+		 */
+		abstract public function SetId($strId);
 
 		/**
 		 * Adds an array of items, or an array of key=>value pairs. Convenient for adding a list from a type table.
@@ -121,7 +128,7 @@
 				$this->AddItem($item, $val, $blnSelected, $strItemGroup, $mixOverrideParameters);
 			};
 			$this->Reindex();
-			$this->_MarkAsModified();
+			$this->MarkAsModified();
 		}
 
 		/**
@@ -162,7 +169,7 @@
 		 * Removes all the items in objListItemArray
 		 */
 		public function RemoveAllItems() {
-			$this->_MarkAsModified();
+			$this->MarkAsModified();
 			$this->objListItemArray = null;
 		}
 
@@ -190,7 +197,7 @@
 
 			$this->objListItemArray[$intCount] = null;
 			unset($this->objListItemArray[$intCount]);
-			$this->_MarkAsModified();
+			$this->MarkAsModified();
 			$this->Reindex();
 		}
 
@@ -209,10 +216,10 @@
 				$objExc->IncrementOffset();
 				throw $objExc;
 			}
-			$objListItem->ControlId = $this->ControlId . '_' . $intIndex;
+			$objListItem->SetId($this->GetId() . '_' . $intIndex);
 			$this->objListItemArray[$intIndex] = $objListItem;
 			$objListItem->Reindex();
-			$this->_MarkAsModified();
+			$this->MarkAsModified();
 		}
 
 		/**
@@ -265,7 +272,7 @@
 				}
 			}
 			if ($blnMarkAsModified) {
-				$this->_MarkAsModified();
+				$this->MarkAsModified();
 			}
 		}
 
@@ -279,14 +286,14 @@
 			$intCount = $this->GetItemCount();
 			for ($intIndex = 0; $intIndex < $intCount; $intIndex++) {
 				$objItem = $this->GetItem($intIndex);
-				$strId = $objItem->ControlId;
+				$strId = $objItem->GetId();
 				$objItem->Selected = in_array($strId, $strIdArray);
 				if ($objItem->GetItemCount()) {
 					$objItem->SetSelectedItemsById($strIdArray, false);
 				}
 			}
 			if ($blnMarkAsModified) {
-				$this->_MarkAsModified();
+				$this->MarkAsModified();
 			}
 		}
 
@@ -302,7 +309,7 @@
 				$objItem->Selected = in_array($intIndex, $intIndexArray);
 			}
 			if ($blnMarkAsModified) {
-				$this->_MarkAsModified();
+				$this->MarkAsModified();
 			}
 		}
 
@@ -339,7 +346,7 @@
 				$objItem->Selected = $blnSelected;
 			}
 			if ($blnMarkAsModified) {
-				$this->_MarkAsModified();
+				$this->MarkAsModified();
 			}
 		}
 
@@ -360,7 +367,7 @@
 				}
 			}
 			if ($blnMarkAsModified) {
-				$this->_MarkAsModified();
+				$this->MarkAsModified();
 			}
 		}
 

--- a/includes/base_controls/QListItemStyle.class.php
+++ b/includes/base_controls/QListItemStyle.class.php
@@ -5,9 +5,7 @@
 	 */
 
 	/**
-	 * This defines the style for an Item for a ListBox
-	 * All the appearance properties should be self-explanatory.
-	 * For more information about ListItem appearance, please see QListItem.class.php
+	 * This defines the style for an Item for a QListControl, which is the base for many different list types.
 	 *
 	 * @package Controls
 	 */

--- a/includes/base_controls/QListItemStyle.class.php
+++ b/includes/base_controls/QListItemStyle.class.php
@@ -8,7 +8,9 @@
 	 * This defines the style for an Item for a QListControl, which is the base for many different list types.
 	 *
 	 * @package Controls
+	 * @property string $OrderedListType type for ordered lists. Expects a QOrderedListType.
 	 */
 	class QListItemStyle extends QTagStyler {
+
 	}
 ?>

--- a/includes/base_controls/QRadioButtonList.class.php
+++ b/includes/base_controls/QRadioButtonList.class.php
@@ -70,16 +70,10 @@
 				$this->SelectedIndex = $_POST[$this->strControlId];
 			}
 			elseif ($this->objForm->IsCheckableControlRendered($this->strControlId)) {
-				if (array_key_exists($this->strControlId, $_POST)) {
-					for ($intIndex = 0; $intIndex < count($this->objItemsArray); $intIndex++) {
-						if ($_POST[$this->strControlId] == $intIndex)
-							$this->objItemsArray[$intIndex]->Selected = true;
-						else
-							$this->objItemsArray[$intIndex]->Selected = false;
-					}
+				if (isset($_POST[$this->strControlId])) {
+					$this->SetSelectedItemsByIndex(array($_POST[$this->strControlId]), false);
 				} else {
-					for ($intIndex = 0; $intIndex < count($this->objItemsArray); $intIndex++) 
-						$this->objItemsArray[$intIndex]->Selected = false;
+					$this->UnselectAllItems(false);
 				}
 			}
 		}
@@ -147,8 +141,8 @@
 		}
 
 		protected function GetControlHtml() {
-			if ((!$this->objItemsArray) || (count($this->objItemsArray) == 0))
-				return "";
+			$intItemCount = $this->GetItemCount();
+			if (!$intItemCount) return '';
 
 			/* Deprecated. Use Margin and Padding on the ItemStyle attribute.
 			if ($this->intCellPadding >= 0)
@@ -217,7 +211,7 @@
 								+ min(($this->ItemCount % $this->intRepeatColumns), $intColIndex)
 								+ $intRowIndex;
 
-						$strItemHtml = $this->GetItemHtml($this->objItemsArray[$intIndex], $intIndex, $this->GetHtmlAttribute('tabindex'), $this->blnWrapLabel);
+						$strItemHtml = $this->GetItemHtml($this->GetItem($intIndex), $intIndex, $this->GetHtmlAttribute('tabindex'), $this->blnWrapLabel);
 						$strCellHtml = QHtml::RenderTag ('td', null, $strItemHtml);
 						$strRowHtml .= $strCellHtml;
 					}
@@ -239,7 +233,7 @@
 			$count = $this->ItemCount;
 			$strToReturn = '';
 			for ($intIndex = 0; $intIndex < $count; $intIndex++) {
-				$strToReturn .= $this->GetItemHtml($this->objItemsArray[$intIndex], $intIndex, $this->GetHtmlAttribute('tabindex'), $this->blnWrapLabel) . "\n";
+				$strToReturn .= $this->GetItemHtml($this->GetItem($intIndex), $intIndex, $this->GetHtmlAttribute('tabindex'), $this->blnWrapLabel) . "\n";
 			}
 			$strToReturn = $this->RenderTag('div', ['id'=>$this->strControlId], null, $strToReturn);
 			return $strToReturn;
@@ -253,7 +247,7 @@
 			$count = $this->ItemCount;
 			$strToReturn = '';
 			for ($intIndex = 0; $intIndex < $count; $intIndex++) {
-				$strHtml = $this->GetItemHtml($this->objItemsArray[$intIndex], $intIndex, $this->GetHtmlAttribute('tabindex'), $this->blnWrapLabel);
+				$strHtml = $this->GetItemHtml($this->GetItem($intIndex), $intIndex, $this->GetHtmlAttribute('tabindex'), $this->blnWrapLabel);
 				$strToReturn .= QHtml::RenderTag('div', null, $strHtml);
 			}
 			$strToReturn = $this->RenderTag('div', ['id'=>$this->strControlId], null, $strToReturn);

--- a/includes/base_controls/_enumerations.inc.php
+++ b/includes/base_controls/_enumerations.inc.php
@@ -443,4 +443,28 @@
 		const None = 'none';
 	}
 
+	/**
+	 * Class QOrderedListType
+	 * For specifying how to number an ordered html list. Goes in the type attribute.
+	 */
+	abstract class QOrderedListType {
+		const Numbers = '1';
+		const UppercaseLetters = 'A';
+		const LowercaseLetters = 'a';
+		const UppercaseRoman = 'I';
+		const LowercaseRoman = 'i';
+	}
+
+	/**
+	 * Class QUnorderedListStyle
+	 * For specifying what to dislay in an unordered html list. Goes in the list-style-type style.
+	 */
+	abstract class QUnorderedListStyle {
+		const Disc = 'disc';
+		const Circle = 'circle';
+		const Square = 'square';
+		const None = 'none';
+	}
+
+
 ?>

--- a/includes/framework/QCryptography.class.php
+++ b/includes/framework/QCryptography.class.php
@@ -258,6 +258,10 @@
 				restore_error_handler();
 			}
 		}
+
+		public function __sleep() {
+			throw new Exception ('Cannot serialize QCryptography');
+		}
 	}
 
 ?>

--- a/includes/framework/QExceptions.class.php
+++ b/includes/framework/QExceptions.class.php
@@ -219,4 +219,42 @@
 			parent::__construct(sprintf('Invalid Form State Data for "%s" object (session may have been lost)', $strFormId), 2);
 		}
 	}
+
+	/**
+	 * @property-read integer $Offset
+	 * @property-read mixed $BackTrace
+	 * @property-read string $Query
+	 */
+	class QDataBindException extends Exception {
+		private $intOffset;
+		private $strTraceArray;
+		private $strQuery;
+
+		public function __construct(QCallerException $objExc) {
+			parent::__construct($objExc->getMessage(), $objExc->getCode());
+			$this->intOffset = $objExc->Offset;
+			$this->strTraceArray = $objExc->TraceArray;
+
+			if ($objExc instanceof QDatabaseExceptionBase)
+				$this->strQuery = $objExc->Query;
+
+			$this->file = $this->strTraceArray[$this->intOffset]['file'];
+			$this->line = $this->strTraceArray[$this->intOffset]['line'];
+		}
+
+		public function __get($strName) {
+			switch($strName) {
+				case "Offset":
+					return $this->intOffset;
+
+				case "BackTrace":
+					$objTraceArray = debug_backtrace();
+					return (var_export($objTraceArray, true));
+
+				case "Query":
+					return $this->strQuery;
+			}
+		}
+	}
+
 ?>

--- a/includes/qcubed.inc.php
+++ b/includes/qcubed.inc.php
@@ -173,6 +173,7 @@
 
 	QApplicationBase::$ClassFile['qlistcontrol'] = __QCUBED_CORE__ . '/base_controls/QListControl.class.php';
 	QApplicationBase::$ClassFile['qlistitem'] = __QCUBED_CORE__ . '/base_controls/QListItem.class.php';
+	QApplicationBase::$ClassFile['qlistitemmanager'] = __QCUBED_CORE__ . '/base_controls/QListItemManager.trait.php';
 	QApplicationBase::$ClassFile['qlistboxbase'] = __QCUBED_CORE__ . '/base_controls/QListBoxBase.class.php';
 	QApplicationBase::$ClassFile['qlistbox'] = __QCUBED__ . '/controls/QListBox.class.php';
 	QApplicationBase::$ClassFile['qlistitemstyle'] = __QCUBED_CORE__ . '/base_controls/QListItemStyle.class.php';
@@ -181,7 +182,6 @@
 	QApplicationBase::$ClassFile['qtreenav'] = __QCUBED_CORE__ . '/base_controls/QTreeNav.class.php';
 	QApplicationBase::$ClassFile['qtreenavitem'] = __QCUBED_CORE__ . '/base_controls/QTreeNavItem.class.php';
 	QApplicationBase::$ClassFile['qhtmllist'] = __QCUBED_CORE__ . '/base_controls/QHtmlList.class.php';
-	QApplicationBase::$ClassFile['qhtmllistitem'] = __QCUBED_CORE__ . '/base_controls/QHtmlList.class.php';
 
 	QApplicationBase::$ClassFile['qtextboxbase'] = __QCUBED_CORE__ . '/base_controls/QTextBoxBase.class.php';
 	QApplicationBase::$ClassFile['qtextbox'] = __QCUBED__ . '/controls/QTextBox.class.php';

--- a/includes/qcubed.inc.php
+++ b/includes/qcubed.inc.php
@@ -172,8 +172,12 @@
 	QApplicationBase::$ClassFile['qlinkbutton'] = __QCUBED_CORE__ . '/base_controls/QLinkButton.class.php';
 
 	QApplicationBase::$ClassFile['qlistcontrol'] = __QCUBED_CORE__ . '/base_controls/QListControl.class.php';
+	QApplicationBase::$ClassFile['qlistitembase'] = __QCUBED_CORE__ . '/base_controls/QListItemBase.class.php';
 	QApplicationBase::$ClassFile['qlistitem'] = __QCUBED_CORE__ . '/base_controls/QListItem.class.php';
 	QApplicationBase::$ClassFile['qlistitemmanager'] = __QCUBED_CORE__ . '/base_controls/QListItemManager.trait.php';
+	QApplicationBase::$ClassFile['qhlistcontrol'] = __QCUBED_CORE__ . '/base_controls/QHListControl.class.php';
+	QApplicationBase::$ClassFile['qhlistitem'] = __QCUBED_CORE__ . '/base_controls/QHListItem.class.php';
+	QApplicationBase::$ClassFile['qdatabinder'] = __QCUBED_CORE__ . '/base_controls/QDataBinder.trait.php';
 	QApplicationBase::$ClassFile['qlistboxbase'] = __QCUBED_CORE__ . '/base_controls/QListBoxBase.class.php';
 	QApplicationBase::$ClassFile['qlistbox'] = __QCUBED__ . '/controls/QListBox.class.php';
 	QApplicationBase::$ClassFile['qlistitemstyle'] = __QCUBED_CORE__ . '/base_controls/QListItemStyle.class.php';
@@ -181,7 +185,6 @@
 	QApplicationBase::$ClassFile['qradiobuttonlist'] = __QCUBED_CORE__ . '/base_controls/QRadioButtonList.class.php';
 	QApplicationBase::$ClassFile['qtreenav'] = __QCUBED_CORE__ . '/base_controls/QTreeNav.class.php';
 	QApplicationBase::$ClassFile['qtreenavitem'] = __QCUBED_CORE__ . '/base_controls/QTreeNavItem.class.php';
-	QApplicationBase::$ClassFile['qhtmllist'] = __QCUBED_CORE__ . '/base_controls/QHtmlList.class.php';
 
 	QApplicationBase::$ClassFile['qtextboxbase'] = __QCUBED_CORE__ . '/base_controls/QTextBoxBase.class.php';
 	QApplicationBase::$ClassFile['qtextbox'] = __QCUBED__ . '/controls/QTextBox.class.php';


### PR DESCRIPTION
My latest take on this. Many competing goals:
1. Reducing code duplication
2. Use new drawing base code
3. Create a common API as much as possible for the QListControl and the QHListControl
4. Simplify

This is my best balance between these. There are a number of new base controls to prevent too much overloading of functionality in controls that don't need it. That came at the cost of some complexity, but it shouldn't be too difficult to follow.

Added some functionally along the way. There is now a QDataBinder trait sharing the data binding code between paginated controls and the QHListControl, and that can be re-used in other future controls if needed. Changed the QHtmlList to QHListControl to better reflect that it is a hierarchical list. And, HTML list was just not very descriptive since everything in the controls is drawing html. Also, if the QHListControl object is given values, it will encrypt the values before sending them to the client browser. Values can be decrypted later if needed at the server level.

There is a QListManager trait for sharing list management code between the QListControl, QHListControl and QHListItem objects, that all manage lists of QListItemBase classes.

There is a QListControlBase that is the base class for the QListControl and QHListControl classes, and that holds shared code between the two.