### PR TITLE
Search parent control hierarchy/lineage by a given method name.

### DIFF
--- a/includes/base_controls/QControlBase.class.php
+++ b/includes/base_controls/QControlBase.class.php
@@ -1793,6 +1793,35 @@
 		}
 
 		/**
+		 * Searches the control and it's hierarchy to see if a method by given name exists.
+		 * This method searches only in the current control and its parents and so on.
+		 * It will not search for the method in any siblings at any stage in the process.
+		 *
+		 * @param string $strMethodName            Name of the method
+		 * @param bool   $blnIncludeCurrentControl Include this control as well?
+		 *
+		 * @return null|QControl The control found in the hierarchy to have the method
+		 *                       Or null if no control was found in the hierarchy with the given name
+		 */
+		public function GetControlFromHierarchyByMethodName($strMethodName, $blnIncludeCurrentControl = true) {
+			if ($blnIncludeCurrentControl == true) {
+				$ctlDelegatorControl = $this;
+			} else {
+				$ctlDelegatorControl = $this->objParentControl;
+			}
+			do {
+				if (method_exists($ctlDelegatorControl, $strMethodName)) {
+					return $ctlDelegatorControl;
+				} else {
+					$ctlDelegatorControl = $ctlDelegatorControl->objParentControl;
+				}
+			} while (!($ctlDelegatorControl instanceof QFormBase));
+
+			// If we are here, we could not find the method in the hierarchy/lineage of this control.
+			return null;
+		}
+
+		/**
 		 * Returns the form associated with the control. Used by the QDataBinder trait.
 		 * @return QForm
 		 */


### PR DESCRIPTION
Quite a few times, we need a panel/control to call a method in that control/panel's  parent. This can be done in cases where a functionality which we need to handle in the parent is to be delegated to child controls. However, sometimes, it might be needed that a child panel be moved into another panel within the parent. In such cases, calling the parent's delegated method will fail.

The best example here would be our AJAX dashboard. When we save an edit (or cancel one), we call a method on the panel which tells its parent (which is a QForm) to close itself. However, if we try to move this functionality into a panel, it will fail because the new parent will not have the method to close the edit panel. 

The new method added can help in such cases. The child panel can now search for the right parent along its hierarchy/lineage by the method name.

**Pro**: You can move a child panel/control into another child and they will still be able to call the delegator function easily, like this:

```
// ...somewhere in an event handler...
// Get the right panel control
$ctlTheRightParentControl = $this->GetControlFromHierarchyByMethodName('TheDelegatorMethodName');

// Then we can call it
$ctlTheRightParentControl->TheDelegatorMethodName('any', 'set', 'of', 'parameters');
```

**Con**: The one downside is that you need to have a unique `TheDelegatorMethodName`, which is actually a trivial task.

