### PR TITLE
add a configuration option to load the javascript files with <script> tags

### DIFF
--- a/includes/configuration/configuration.inc.php.sample
+++ b/includes/configuration/configuration.inc.php.sample
@@ -143,6 +143,10 @@ if (!defined('SERVER_INSTANCE')) {
 			define ('__APP_IMAGE_ASSETS__', __SUBDIRECTORY__ . '/assets/images');
 			define ('__APP_PHP_ASSETS__', __SUBDIRECTORY__ . '/assets/php');
 
+			// When __PRELOAD_JS_FILES__ is set to true, the core and plugin javascript files will be included into the
+			// page with <script> tags, rather than loaded dynamically with qc.loadJavaScriptFile
+			define ('__PRELOAD_JS_FILES__', false);
+
 			// There are two ways to add jQuery JS files to QCubed. Either by absolute paths (Google CDN of
 			// the jQuery library is awesome! It's the default option below) - or by using the jQuery
 			// installation that's local to QCubed (in that case, paths must be relative to __JS_ASSETS__

--- a/includes/qcubed/_core/base_controls/QFormBase.class.php
+++ b/includes/qcubed/_core/base_controls/QFormBase.class.php
@@ -1460,6 +1460,43 @@
 			$this->strIncludedJavaScriptFileArray = array();
 			// Figure out initial list of JavaScriptIncludes
 			$strJavaScriptArray = $this->ProcessJavaScriptList(__JQUERY_BASE__ . ', ' . __JQUERY_EFFECTS__ . ',jquery/jquery.ajaxq-0.0.1.js,' . __QCUBED_JS_CORE__);
+
+			// Next, go through all controls and gather up any JS or CSS to run or Form Attributes to modify
+			// due to dynamically created controls
+			$strJavaScriptToAddArray = array();
+			$strStyleSheetToAddArray = array();
+			$strFormAttributeToModifyArray = array();
+
+			foreach ($this->GetAllControls() as $objControl) {
+				// Include any JavaScripts?  The control would have a
+				// comma-delimited list of javascript files to include (if applicable)
+				if ($strScriptArray = $this->ProcessJavaScriptList($objControl->JavaScripts))
+					$strJavaScriptToAddArray = array_merge($strJavaScriptToAddArray, $strScriptArray);
+
+				// Include any StyleSheets?  The control would have a
+				// comma-delimited list of stylesheet files to include (if applicable)
+				if ($strScriptArray = $this->ProcessStyleSheetList($objControl->StyleSheets))
+					$strStyleSheetToAddArray = array_merge($strStyleSheetToAddArray, $strScriptArray);
+
+				// Form Attributes?
+				if ($objControl->FormAttributes) {
+					foreach ($objControl->FormAttributes as $strKey=>$strValue) {
+						if (!array_key_exists($strKey, $this->strFormAttributeArray)) {
+							$this->strFormAttributeArray[$strKey] = $strValue;
+							$strFormAttributeToModifyArray[$strKey] = $strValue;
+						} else if ($this->strFormAttributeArray[$strKey] != $strValue) {
+							$this->strFormAttributeArray[$strKey] = $strValue;
+							$strFormAttributeToModifyArray[$strKey] = $strValue;
+						}
+					}
+				}
+			}
+
+			if (defined('__PRELOAD_JS_FILES__') && __PRELOAD_JS_FILES__) {
+				$strJavaScriptArray = array_merge($strJavaScriptArray, $strJavaScriptToAddArray);
+				$strJavaScriptToAddArray = array();
+			}
+
 			// Setup IncludeJs
 			$strToReturn = "\r\n";
 
@@ -1503,37 +1540,6 @@
 			foreach ($strEndScriptArray as $strEndScript)
 				$strEndScriptCommands[trim($strEndScript)] = true;
 			$strEndScript = implode(";\n", array_keys($strEndScriptCommands));
-
-			// Next, go through all controls and gather up any JS or CSS to run or Form Attributes to modify
-			// due to dynamically created controls
-			$strJavaScriptToAddArray = array();
-			$strStyleSheetToAddArray = array();
-			$strFormAttributeToModifyArray = array();
-
-			foreach ($this->GetAllControls() as $objControl) {
-				// Include any JavaScripts?  The control would have a
-				// comma-delimited list of javascript files to include (if applicable)
-				if ($strScriptArray = $this->ProcessJavaScriptList($objControl->JavaScripts))
-					$strJavaScriptToAddArray = array_merge($strJavaScriptToAddArray, $strScriptArray);
-
-				// Include any StyleSheets?  The control would have a
-				// comma-delimited list of stylesheet files to include (if applicable)
-				if ($strScriptArray = $this->ProcessStyleSheetList($objControl->StyleSheets))
-					$strStyleSheetToAddArray = array_merge($strStyleSheetToAddArray, $strScriptArray);
-
-				// Form Attributes?
-				if ($objControl->FormAttributes) {
-					foreach ($objControl->FormAttributes as $strKey=>$strValue) {
-						if (!array_key_exists($strKey, $this->strFormAttributeArray)) {
-							$this->strFormAttributeArray[$strKey] = $strValue;
-							$strFormAttributeToModifyArray[$strKey] = $strValue;
-						} else if ($this->strFormAttributeArray[$strKey] != $strValue) {
-							$this->strFormAttributeArray[$strKey] = $strValue;
-							$strFormAttributeToModifyArray[$strKey] = $strValue;
-						}
-					}
-				}
-			}
 
 			// First, alter any <Form> settings that need to be altered
 			foreach ($strFormAttributeToModifyArray as $strKey=>$strValue)


### PR DESCRIPTION
This change adds a new configuration option called `__PRELOAD_JS_FILES__`, which allows loading the javascript files with `<script>` tags rather than with `qc.loadJavaScriptFile`.
The current approach of loading control-specific (including plugin) javascript files with `qc.loadJavaScriptFile` creates lots of problems when debugging with firebug or chrome.
By default this flag is off, so the change is fully backward compatible.
The big block of code that shows as a diff, is not new, it's just moved up within the same function. 