### PR TITLE
Update QCache.class.php

### DIFF
--- a/includes/qcubed/_core/framework/QCache.class.php
+++ b/includes/qcubed/_core/framework/QCache.class.php
@@ -24,31 +24,32 @@
 		}
 
 		public function GetData() {
-			// First, ensure that the cache file exits
-			if (file_exists($this->GetFilePath())) {
+			// First, ensure that the cache file exists
+			$filepath = $this->GetFilePath(); //cache the filepath in stead of running sprintf multiple times
+			if (file_exists($filepath)) {
 				if (count($this->strCheckFilesArray)) {
 					// Now, get the current hash of the checkfiles
 					$strHash = $this->GetCheckFilesHash();
 
 					// If No CheckFiles, the delete cache file and return false
 					if ($strHash === false) {
-						unlink($this->GetFilePath());
+						@unlink($filepath);
 						return false;
 					}
 
 					// If Hash File doesn't exist or if the values don't match, delete and return
-					$strHashFile = $this->GetFilePath() . '.hash';
-					if (!file_exists($strHashFile) ||
-						($strHash != file_get_contents($strHashFile))) {
-						unlink($this->GetFilePath());
+					$strHashFile = $filepath . '.hash';
+					if (!file_exists($strHashFile) || ($strHash != file_get_contents($strHashFile))) {
+						@unlink($filepath);
 						return false;
 					}
 				}
 
 				// If we're here, return the contents of the cache file
-				return file_get_contents($this->GetFilePath());
-			} else
+				return file_get_contents($filepath);
+			} else {
 				return false;
+			}
 		}
 
 		public function SaveData($strData) {


### PR DESCRIPTION
QCache runs sprintf multiple times in the same method. I've changed this so the variable $filepath is used.

Also, it sometimes happens that an unlink fails because a file does not exist. 
This should be impossible since we are already checking if the file_exists at the start of the method. But the reality is different. 
My guess is that there are multiple GetData calls by different users and that they sometimes overlap. 

To fix this I added an @ to the unlink. This will avoid a crash if the file does not exist.