### PR TITLE
bugfix-DefaultWatcherToTrue

### DIFF
--- a/includes/codegen/templates/db_orm/class_gen/_main.tpl.php
+++ b/includes/codegen/templates/db_orm/class_gen/_main.tpl.php
@@ -35,8 +35,8 @@
 
 		use QModelTrait;
 
-		/** @var boolean Set to true in superclass to be able to watch changes to this class. */
-		public static $blnWatchChanges = false;
+		/** @var boolean Set to false in superclass to save a little time if this db object should not be watched for changes. */
+		public static $blnWatchChanges = true;
 
 <?php if ($objTable->PrimaryKeyColumnArray)  { ?>
 		/** @var <?= $objTable->ClassName ?>[] Short term cached <?= $objTable->ClassName ?> objects */

--- a/includes/codegen/templates/db_orm/class_subclass/_main.tpl.php
+++ b/includes/codegen/templates/db_orm/class_subclass/_main.tpl.php
@@ -27,10 +27,6 @@
 	 *
 	 */
 	class <?= $objTable->ClassName ?> extends <?= $objTable->ClassName ?>Gen {
-
-		// Uncomment the following line to enable other users to watch changes on this table.
-		//public static $blnWatchChanges = true;
-
 		/**
 		 * Default "to string" handler
 		 * Allows pages to _p()/echo()/print() this object, and to define the default


### PR DESCRIPTION
Changing default watcher state to true for all generated classes. Will not do anything until a watcher class is defined, but this fixes a bug showing up on the examples page, and an annoying problem as you turn watchers on.