### PR TITLE
bugfix-DbNullHandling

### DIFF
--- a/includes/codegen/templates/db_orm/class_gen/instantiation_methods.tpl.php
+++ b/includes/codegen/templates/db_orm/class_gen/instantiation_methods.tpl.php
@@ -34,6 +34,7 @@
 			}
 
 			$strColumns = $objDbRow->GetColumnNameArray();
+			$strColumnKeys = array_fill_keys(array_keys($strColumns), 1); // to be able to use isset
 
 <?php if ($objTable->PrimaryKeyColumnArray)  { // Optimize top level accesses?>
 			$key = static::GetRowPrimaryKey ($objDbRow, $strAliasPrefix, $strColumnAliasArray);
@@ -74,14 +75,16 @@
 <?php foreach ($objTable->ColumnArray as $objColumn) { ?>
 				$strAlias = $strAliasPrefix . '<?= $objColumn->Name ?>';
 				$strAliasName = !empty($strColumnAliasArray[$strAlias]) ? $strColumnAliasArray[$strAlias] : $strAlias;
-				if (isset ($strColumns[$strAliasName])) {
+				if (isset ($strColumnKeys[$strAliasName])) {
 					$mixVal = $strColumns[$strAliasName];
 <?php if ($objColumn->VariableType == QType::Boolean) { ?>
 					$objToReturn-><?= $objColumn->VariableName ?> = $objDbRow->ResolveBooleanValue($mixVal);
 <?php } else { ?>
 <?php 	if ($s = QDatabaseCodeGen::GetCastString($objColumn)) { ?>
-					<?= $s ?>
+					if ($mixVal !== null) {
+						<?= $s ?>
 
+					}
 <?php 	} ?>
 					$objToReturn-><?= $objColumn->VariableName ?> = $mixVal;
 <?php } ?>
@@ -89,7 +92,7 @@
 					$objToReturn->__<?= $objColumn->VariableName ?> = $mixVal;
 <?php } ?>
 				}
-				elseif (!array_key_exists($strAliasName, $strColumns)) {
+				else {
 					$blnNoCache = true;
 				}
 <?php } ?>

--- a/includes/framework/QDatabaseBase.class.php
+++ b/includes/framework/QDatabaseBase.class.php
@@ -1106,6 +1106,9 @@
 		 * @return bool
 		 */
 		public function ResolveBooleanValue ($mixValue) {
+			if ($mixValue === null) {
+				return null;
+			}
 			return ((bool)$mixValue);
 		}
 


### PR DESCRIPTION
Fixing a very corner case problem. There is a commented out Initialize function generated for all the Models. If you uncomment that, it will automatically initialize to default values. The problem occurred when the value in the database was a null, but the default value was not null. In that case, the default value would be put in the loaded object, rather than the null in the database.

This fix also improves performance on larger tables by avoiding the array_key_exists calls and rather using only isset, which is faster, and is exponentially faster as the table gets bigger.