### PR TITLE
bugfix-QQBetweenTypes

### DIFF
--- a/includes/framework/QQuery.class.php
+++ b/includes/framework/QQuery.class.php
@@ -923,25 +923,19 @@
 
 	class QQConditionBetween extends QQConditionComparison {
 		protected $mixOperandTwo;
-		public function __construct(QQNode $objQueryNode, $strMinValue, $strMaxValue) {
+		public function __construct(QQNode $objQueryNode, $mixMinValue, $mixMaxValue) {
 			$this->objQueryNode = $objQueryNode;
 			if (!$objQueryNode->_ParentNode)
 				throw new QInvalidCastException('Unable to cast "' . $objQueryNode->_Name . '" table to Column-based QQNode', 3);
 
 			try {
-				$this->mixOperand = QType::Cast($strMinValue, QType::String);
-				$this->mixOperandTwo = QType::Cast($strMaxValue, QType::String);
+				$this->mixOperand = $mixMinValue;
+				$this->mixOperandTwo = $mixMaxValue;
 			} catch (QCallerException $objExc) {
 				$objExc->IncrementOffset();
 				$objExc->IncrementOffset();
 				throw $objExc;
 			}
-
-			if ($strMinValue instanceof QQNamedValue)
-				$this->mixOperand = $strMinValue;
-			if ($strMaxValue instanceof QQNamedValue)
-				$this->mixOperandTwo = $strMaxValue;
-
 		}
 		public function UpdateQueryBuilder(QQueryBuilder $objBuilder) {
 			$mixOperand = $this->mixOperand;
@@ -1077,8 +1071,8 @@
 		static public function NotLike(QQNode $objQueryNode, $strValue) {
 			return new QQConditionNotLike($objQueryNode, $strValue);
 		}
-		static public function Between(QQNode $objQueryNode, $strMinValue, $strMaxValue) {
-			return new QQConditionBetween($objQueryNode, $strMinValue, $strMaxValue);
+		static public function Between(QQNode $objQueryNode, $mixMinValue, $mixMaxValue) {
+			return new QQConditionBetween($objQueryNode, $mixMinValue, $mixMaxValue);
 		}
 		static public function NotBetween(QQNode $objQueryNode, $strMinValue, $strMaxValue) {
 			return new QQConditionNotBetween($objQueryNode, $strMinValue, $strMaxValue);

--- a/includes/tests/qcubed-unit/QTypeTests.php
+++ b/includes/tests/qcubed-unit/QTypeTests.php
@@ -95,5 +95,23 @@ class QTypeTests extends QUnitTestCaseBase {
 			}
 		}
 	}
+
+	public function testDbTypeCasting() {
+		$dt1 = new QDateTime('Jan 15 2006');
+		$dt2 = new QDateTime('Mar 15 2006');
+
+		$cond = QQ::Between(QQN::Project()->StartDate, $dt1, $dt2);
+		$a = Project::QueryArray($cond);
+		$this->assertEqual(count($a), 2, "Between 2 QDateTime types works");
+
+
+		$cond = QQ::Between(QQN::Project()->Budget, 2000, 3000);
+		$a = Project::QueryArray($cond);
+		$this->assertEqual(count($a), 1, "Between 2 int types works");
+
+		$cond = QQ::Between(QQN::Project()->Name, 'A', 'C');
+		$a = Project::QueryArray($cond);
+		$this->assertEqual(count($a), 3, "Between 2 string types works");
+	}
 }
 ?>


### PR DESCRIPTION
Fixing QQ::Between to accept any type of data that is convertible to a SQL value, rather than just strings.