### PR TITLE
bugfix-AddMonth

### DIFF
--- a/includes/framework/QDateTime.class.php
+++ b/includes/framework/QDateTime.class.php
@@ -792,13 +792,19 @@
 		}
 
 		/**
-		 * Add months to the time.
+		 * Add months to the time. If the day on the new month is greater than the month will allow, the day is adjusted
+		 * to be the last day of that month.
 		 *
 		 * @param integer $intMonths
 		 * @return QDateTime
 		 */
 		public function AddMonths($intMonths){
+			$prevDay = $this->Day;
 			$this->Month += $intMonths;
+			if ($this->Day != $prevDay) {
+				$this->Day = 1;
+				$this->AddDays (-1);
+			}
 			return $this;
 		}
 


### PR DESCRIPTION
When adding months, if the day is at the end of the month, there is a possibility that this will cause the add month to roll over to the beginning of the next month. This make an adjustment so that it will just go to the end of the correct month. In other words, if you add one month to January 31, this will make sure the date is February 28, and not March 3.