### PR TITLE
bugfix-ConnectorClassName

### DIFF
--- a/includes/codegen/QCodeGenBase.class.php
+++ b/includes/codegen/QCodeGenBase.class.php
@@ -820,7 +820,7 @@
 		 * @return string Class name of control which can handle this column's data
 		 * @throws Exception
 		 */
-		protected function ModelConnectorControlClass($objColumn) {
+		public function ModelConnectorControlClass($objColumn) {
 
 			// Is the class specified by the developer?
 			if ($o = $objColumn->Options) {


### PR DESCRIPTION
Making this public so that it is usable by the code generation routines to get the name of the current class. Its a little faster and easier than GetCodeGenerator()->GetClassName()