### PR TITLE
bugfix-htmlValidationErrors

### DIFF
--- a/assets/js/qcubed.js
+++ b/assets/js/qcubed.js
@@ -249,9 +249,10 @@ qcubed = {
                     case "checkbox":
                         if (index >= 0) {
                             if ($element.is(":checked")) {
-                                strPostData += "&" + strControlName + "=" + $element.is(":checked");
+                                strPostData += "&" + strControlName + "=" + $element.val();
                             }
                         } else {
+                            // TODO: use value instead of is checked
                             strPostData += "&" + strControlName + "=" + $element.is(":checked");
                         }
                         break;

--- a/assets/php/tests/ui_basic.php
+++ b/assets/php/tests/ui_basic.php
@@ -1,112 +1,112 @@
 <?php
-    require_once('../qcubed.inc.php');
-    
-	class BasicForm extends QForm {
-		protected $txtText;
-		protected $txtText2;
-		protected $lstSelect;
-		protected $lstSelect2;
-		protected $lstCheck;
-		protected $lstCheck2;
-		protected $lstRadio;
-		protected $chkCheck;
-		protected $rdoRadio1;
-		protected $rdoRadio2;
-		protected $rdoRadio3;
+require_once('../qcubed.inc.php');
 
-		/** @var  QImageButton */
-		protected $btnImage;
+class BasicForm extends QForm {
+	protected $txtText;
+	protected $txtText2;
+	protected $lstSelect;
+	protected $lstSelect2;
+	protected $lstCheck;
+	protected $lstCheck2;
+	protected $lstRadio;
+	protected $chkCheck;
+	protected $rdoRadio1;
+	protected $rdoRadio2;
+	protected $rdoRadio3;
 
-		protected $btnServer;
-		protected $btnAjax;
+	/** @var  QImageButton */
+	protected $btnImage;
 
-		protected function Form_Create() {
-			$this->txtText = new QTextBox($this);
-			$this->txtText->Text = 'Default';
-			$this->txtText->Name = 'TextBox';
+	protected $btnServer;
+	protected $btnAjax;
 
-			$this->txtText2 = new QTextBox($this);
-			$this->txtText2->Text = 'Big';
-			$this->txtText2->Name = 'TextBox';
-			$this->txtText2->TextMode = QTextMode::MultiLine;
-			$this->txtText2->Rows = 3;
+	protected function Form_Create() {
+		$this->txtText = new QTextBox($this);
+		$this->txtText->Text = 'Default';
+		$this->txtText->Name = 'TextBox';
 
-			$this->chkCheck = new QCheckBox($this);
-			$this->chkCheck->Name = 'CheckBox';
-			$this->chkCheck->WrapLabel = true;
+		$this->txtText2 = new QTextBox($this);
+		$this->txtText2->Text = 'Big';
+		$this->txtText2->Name = 'TextBox';
+		$this->txtText2->TextMode = QTextMode::MultiLine;
+		$this->txtText2->Rows = 3;
 
-			$items = array (1=>'Item1', 2=>'Item2', 3=>'Item3');
-			$this->lstSelect = new QListBox($this);
-			$this->lstSelect->AddItems ($items);
-			$this->lstSelect->Name = 'Select';
+		$this->chkCheck = new QCheckBox($this);
+		$this->chkCheck->Name = 'CheckBox';
+		$this->chkCheck->WrapLabel = true;
 
-			$this->lstSelect2 = new QListBox($this);
-			$this->lstSelect2->AddItems ($items);
-			$this->lstSelect2->Name = 'Multiselect';
-			$this->lstSelect2->SelectionMode = QSelectionMode::Multiple;
+		$items = array (1=>'Item1', 2=>'Item2', 3=>'Item3');
+		$this->lstSelect = new QListBox($this);
+		$this->lstSelect->AddItems ($items);
+		$this->lstSelect->Name = 'Select';
 
-			$this->lstCheck = new QCheckBoxList($this);
-			$this->lstCheck->AddItems ($items);
-			$this->lstCheck->Name = 'Check List';
-			$this->lstCheck->RepeatDirection = QRepeatDirection::Horizontal;
-			$this->lstCheck->RepeatColumns = 4;
+		$this->lstSelect2 = new QListBox($this);
+		$this->lstSelect2->AddItems ($items);
+		$this->lstSelect2->Name = 'Multiselect';
+		$this->lstSelect2->SelectionMode = QSelectionMode::Multiple;
 
-			$this->lstCheck2 = new QCheckBoxList($this);
-			$this->lstCheck2->AddItems ($items);
-			$this->lstCheck2->Name = 'Check List';
-			$this->lstCheck2->RepeatColumns = 1;
-			$this->lstCheck2->MaxHeight = 100;
-			$this->lstCheck2->WrapLabel = true;
-			$this->lstCheck2->Name = 'Check List 2';
+		$this->lstCheck = new QCheckBoxList($this);
+		$this->lstCheck->AddItems ($items);
+		$this->lstCheck->Name = 'Check List';
+		$this->lstCheck->RepeatDirection = QRepeatDirection::Horizontal;
+		$this->lstCheck->RepeatColumns = 4;
 
-			$this->lstRadio = new QRadioButtonList($this);
-			$this->lstRadio->AddItems ($items);
-			$this->lstRadio->Name = 'Radio List';
-			$this->lstRadio->RepeatDirection = QRepeatDirection::Horizontal;
-			$this->lstRadio->RepeatColumns = 4;
-			$this->lstRadio->SelectedIndex = 1;
+		$this->lstCheck2 = new QCheckBoxList($this);
+		$this->lstCheck2->AddItems ($items);
+		$this->lstCheck2->Name = 'Check List';
+		$this->lstCheck2->RepeatColumns = 1;
+		$this->lstCheck2->MaxHeight = 100;
+		$this->lstCheck2->WrapLabel = true;
+		$this->lstCheck2->Name = 'Check List 2';
 
-			$this->rdoRadio1 = new QRadioButton($this);
-			$this->rdoRadio1->Name = 'Item 1';
-			$this->rdoRadio1->GroupName = 'MyGroup';
-			$this->rdoRadio2 = new QRadioButton($this);
-			$this->rdoRadio2->Name = 'Item 2';
-			$this->rdoRadio2->GroupName = 'MyGroup';
-			$this->rdoRadio3 = new QRadioButton($this);
-			$this->rdoRadio3->Name = 'Item 3';
-			$this->rdoRadio3->GroupName = 'MyGroup';
+		$this->lstRadio = new QRadioButtonList($this);
+		$this->lstRadio->AddItems ($items);
+		$this->lstRadio->Name = 'Radio List';
+		$this->lstRadio->RepeatDirection = QRepeatDirection::Horizontal;
+		$this->lstRadio->RepeatColumns = 4;
+		$this->lstRadio->SelectedIndex = 1;
 
-			$this->btnImage = new QImageButton($this);
-			$this->btnImage->Name = 'Image Button';
-			$this->btnImage->ImageUrl = __PHP_ASSETS__ . '/examples/images/data_model_thumbnail.png';
-			$this->btnImage->AddAction (new QClickEvent(), new QRegisterClickPositionAction());
+		$this->rdoRadio1 = new QRadioButton($this);
+		$this->rdoRadio1->Name = 'Item 1';
+		$this->rdoRadio1->GroupName = 'MyGroup';
+		$this->rdoRadio2 = new QRadioButton($this);
+		$this->rdoRadio2->Name = 'Item 2';
+		$this->rdoRadio2->GroupName = 'MyGroup';
+		$this->rdoRadio3 = new QRadioButton($this);
+		$this->rdoRadio3->Name = 'Item 3';
+		$this->rdoRadio3->GroupName = 'MyGroup';
 
-			$this->btnServer = new QButton ($this);
-			$this->btnServer->Text = 'Server Submit';
-			$this->btnServer->AddAction(new QClickEvent(), new QServerAction('submit_click'));
+		$this->btnImage = new QImageButton($this);
+		$this->btnImage->Name = 'Image Button';
+		$this->btnImage->ImageUrl = __PHP_ASSETS__ . '/examples/images/data_model_thumbnail.png';
+		$this->btnImage->AddAction (new QClickEvent(), new QRegisterClickPositionAction());
 
-			$this->btnAjax = new QButton ($this);
-			$this->btnAjax->Text = 'Ajax Submit';
-			$this->btnAjax->AddAction(new QClickEvent(), new QAjaxAction('submit_click'));
-		}
+		$this->btnServer = new QButton ($this);
+		$this->btnServer->Text = 'Server Submit';
+		$this->btnServer->AddAction(new QClickEvent(), new QServerAction('submit_click'));
 
-		protected function submit_click($strFormId, $strControlId, $strParameter) {
-			$strTemp = $this->txtText->Text;
-			$this->txtText->Text = $this->txtText2->Text;
-			$this->txtText2->Text = $strTemp;
-
-			$this->chkCheck->Warning = 'Value = ' . $this->chkCheck->Checked;
-			$this->lstSelect->Warning = 'Value = ' . $this->lstSelect->SelectedValue;
-			$this->lstSelect2->Warning = 'Values = ' . implode (',', $this->lstSelect2->SelectedValues);
-			$this->lstCheck->Warning = 'Values = ' . implode (',', $this->lstCheck->SelectedValues);
-			$this->lstCheck2->Warning = 'Values = ' . implode (',', $this->lstCheck2->SelectedValues);
-			$this->lstRadio->Warning = 'Value = ' . $this->lstRadio->SelectedValue;
-			$this->rdoRadio1->Warning = 'Value = ' . $this->rdoRadio1->Checked;
-			$this->rdoRadio2->Warning = 'Value = ' . $this->rdoRadio2->Checked;
-			$this->rdoRadio3->Warning = 'Value = ' . $this->rdoRadio3->Checked;
-			$this->btnImage->Warning = 'X = ' . $this->btnImage->ClickX . '; Y = ' . $this->btnImage->ClickY;
-		}
-		
+		$this->btnAjax = new QButton ($this);
+		$this->btnAjax->Text = 'Ajax Submit';
+		$this->btnAjax->AddAction(new QClickEvent(), new QAjaxAction('submit_click'));
 	}
-	BasicForm::Run('BasicForm');
-?>
+
+	protected function submit_click($strFormId, $strControlId, $strParameter) {
+		$strTemp = $this->txtText->Text;
+		$this->txtText->Text = $this->txtText2->Text;
+		$this->txtText2->Text = $strTemp;
+
+		$this->chkCheck->Warning = 'Value = ' . $this->chkCheck->Checked;
+		$this->lstSelect->Warning = 'Value = ' . $this->lstSelect->SelectedValue;
+		$this->lstSelect2->Warning = 'Values = ' . implode (',', $this->lstSelect2->SelectedValues);
+		$this->lstCheck->Warning = 'Values = ' . implode (',', $this->lstCheck->SelectedValues);
+		$this->lstCheck2->Warning = 'Values = ' . implode (',', $this->lstCheck2->SelectedValues);
+		$this->lstRadio->Warning = 'Value = ' . $this->lstRadio->SelectedValue;
+		$this->rdoRadio1->Warning = 'Value = ' . $this->rdoRadio1->Checked;
+		$this->rdoRadio2->Warning = 'Value = ' . $this->rdoRadio2->Checked;
+		$this->rdoRadio3->Warning = 'Value = ' . $this->rdoRadio3->Checked;
+		$this->btnImage->Warning = 'X = ' . $this->btnImage->ClickX . '; Y = ' . $this->btnImage->ClickY;
+	}
+
+}
+
+BasicForm::Run('BasicForm');

--- a/assets/php/tests/ui_basic.tpl.php
+++ b/assets/php/tests/ui_basic.tpl.php
@@ -1,4 +1,9 @@
-<?php require('../../../../../../project/includes/configuration/header.inc.php'); ?>
+<?php
+	$strPageTitle = 'Basic Test';
+ 	require('../../../../../../project/includes/configuration/header.inc.php');
+
+?>
+
 <?php $this->RenderBegin(); ?>
 <?php $this->txtText->RenderWithName(); ?>
 <?php $this->txtText2->RenderWithName(); ?>

--- a/includes/base_controls/QCheckBox.class.php
+++ b/includes/base_controls/QCheckBox.class.php
@@ -80,7 +80,7 @@
 		 * @return string THe HTML for the control
 		 */
 		protected function GetControlHtml() {
-			$attrOverride = array('type'=>'checkbox', 'name'=>$this->strControlId);
+			$attrOverride = array('type'=>'checkbox', 'name'=>$this->strControlId, 'value'=>'true');
 			return $this->RenderButton($attrOverride);
 		}
 

--- a/includes/base_controls/QCheckBoxList.class.php
+++ b/includes/base_controls/QCheckBoxList.class.php
@@ -71,13 +71,13 @@
 			if (QApplication::$RequestMode == QRequestMode::Ajax) {
 				// Ajax will only send information about controls that are on the screen, so we know they are rendered
 				if (isset($_POST[$this->strControlId]) && is_array($_POST[$this->strControlId])) {
-					$a = array_keys($_POST[$this->strControlId]);
+					$a = $_POST[$this->strControlId];
 					$this->SetSelectedItemsByIndex($a, false);
 				}
 			}
 			elseif ($this->objForm->IsCheckableControlRendered($this->strControlId)) {
 				if (isset($_POST[$this->strControlId]) && is_array($_POST[$this->strControlId])) {
-					$a = array_keys($_POST[$this->strControlId]);
+					$a = $_POST[$this->strControlId];
 					$this->SetSelectedItemsByIndex($a, false);
 				} else {
 					$this->UnselectAllItems(false);
@@ -121,7 +121,8 @@
 
 			$objStyles = new QTagStyler();
 			$objStyles->SetHtmlAttribute('type', 'checkbox');
-			$objStyles->SetHtmlAttribute('name', $this->strControlId . '[' . $intIndex . ']');
+			$objStyles->SetHtmlAttribute('name', $this->strControlId . '[]');
+			$objStyles->SetHtmlAttribute('value', $intIndex);
 
 			$strIndexedId = $objItem->Id;
 			$objStyles->SetHtmlAttribute('id', $strIndexedId);

--- a/includes/base_controls/QControlBase.class.php
+++ b/includes/base_controls/QControlBase.class.php
@@ -1530,7 +1530,7 @@
 				$strInstructions = '';
 			}
 			
-			$strToReturn = sprintf('<div class="%s"><label for="%s">%s</label>%s</div>', $strLabelClass, $this->strControlId, $this->strName, $strInstructions);
+			$strToReturn = sprintf('<div class="%s"><label>%s</label>%s</div>', $strLabelClass, $this->strName, $strInstructions);
 
 			// Render the Right side
 			$strMessage = '';

--- a/includes/base_controls/QImageButton.class.php
+++ b/includes/base_controls/QImageButton.class.php
@@ -68,15 +68,12 @@
 				$strStyle = sprintf('style="%s"', $strStyle);
 
 			if ($this->blnPrimaryButton) {
-				$strToReturn = sprintf('<input type="image" name="%s" id="%s" %s%s />',
-					$this->strControlId,
+				$strToReturn = sprintf('<input type="image" name="%s" %s%s />',
 					$this->strControlId,
 					$this->GetAttributes(),
 					$strStyle);
 			} else {
-				$strToReturn = sprintf('<img name="%s" id="%s" %s%s />',
-					$this->strControlId,
-					$this->strControlId,
+				$strToReturn = sprintf('<img  %s%s />',
 					$this->GetAttributes(),
 					$strStyle);
 			}

--- a/includes/watchers/QWatcherDB.class.php
+++ b/includes/watchers/QWatcherDB.class.php
@@ -147,6 +147,3 @@
 			return false;
 		}
 	}
-	
-?>
-	


### PR DESCRIPTION
Fixing up some html validation errors:
- Checkboxes must have a value attribute. Required doing checkbox lists a little differently.
- "for" attribute in labels must point to an actual form control
- Name field in img tags is deprecated
- QWatcherDB was inserting a tab into the html. Removed trailing php tag to fix permanently.