### PR TITLE
Don't add the strVirtDir and strSubDir variables to the Launch link if they are both empty.

### DIFF
--- a/assets/_core/php/_devtools/installer/step_3.php
+++ b/assets/_core/php/_devtools/installer/step_3.php
@@ -183,7 +183,11 @@
 				switch ($strFileCreationStatus) {
 					case 'exists':
 					case 'creation_failed':
-						echo '<br/> <a href="' . $strVirtDir . $strSubDir . '/assets/_core/php/_devtools/config_checker.php">Launch the config checker</a>';
+						echo '<br/> <a href="';
+						if (!empty($strVirtDir) || !empty($strSubDir)) {
+							echo $strVirtDir . $strSubDir
+						};
+						echo '/assets/_core/php/_devtools/config_checker.php">Launch the config checker</a>';
 						break;
 					case 'created':
 						?>


### PR DESCRIPTION
This is a patch to fix issue #690. If there is no content in strVirtDir or strSubDir then don't add them to the link path since it removes the host.

**Please, please, please test these before you merge.** I tested it 5 times on Ubuntu 14.04 on DigitalOcean with Apache 2.4.7 and PHP 5.5.9:

Three tests were putting it in different locations on the file system but always in the virtualhost root: Always had the issue from #690, but this patch fixed them all.

One test was with a virtual directory and I didn't have any problems with the link before or after the patch was applied.

The last test was with a subdirectory and I didn't have any problems with the link before or after the patch was applied.

I used existing code as examples for style, so I'm pretty sure that's okay, but let me know if there's anything else that needs fixing, or if it doesn't work for you, or if you can't replicate the issue, or... anything.