### PR TITLE
Pull Request for - QSqlServer2005Database.class.php - Codegen fails if the table has no index column and no primary key (Issue #692)

### DIFF
--- a/includes/qcubed/_core/database/QSqlServer2005Database.class.php
+++ b/includes/qcubed/_core/database/QSqlServer2005Database.class.php
@@ -550,8 +550,8 @@
 			$strColumnArray = sqlsrv_fetch_array($this->objSqlSrvResult);
 			if ($strColumnArray === false) {
 				// Determine the errorinformation
-				$this->GetErrorInformation($strErrorinformation, $strErrorCode);
-				throw new QSqlServer2005DatabaseException($strErrorinformation, $strErrorCode, $strNonQuery);
+				$this->objDb->GetErrorInformation($strErrorinformation, $strErrorCode);
+				throw new QSqlServer2005DatabaseException($strErrorinformation, $strErrorCode, null);
 			}
 			return $strColumnArray;
 		}


### PR DESCRIPTION
Please see link below for issue description.

[Issue 692 - Description Link](https://github.com/qcubed/framework/issues/692)
