### PR TITLE
Added a few useful properties to QDateTimePicker

### DIFF
--- a/includes/base_controls/QDateTimePicker.class.php
+++ b/includes/base_controls/QDateTimePicker.class.php
@@ -267,7 +267,7 @@
 					if (!$this->blnRequired || $dttDateTime->IsTimeNull())
 						if ($this->blnAllowBlankTime)
 							$strHourListBox .= '<option value="">--</option>';
-					for ($intHour = 0; $intHour <= 23; $intHour++) {
+					for ($intHour = 0; $intHour <= 23; $intHour += $this->intHourInterval) {
 						if (!$dttDateTime->IsTimeNull() && ($dttDateTime->Hour == $intHour))
 							$strSelected = ' selected="selected"';
 						else
@@ -279,13 +279,12 @@
 					}
 					$strHourListBox .= '</select>';
 
-
 					// Minute
 					$strMinuteListBox = sprintf('<select name="%s_lstMinute" id="%s_lstMinute" class="minute" %s>', $this->strControlId, $this->strControlId, $strAttributes);
 					if (!$this->blnRequired || $dttDateTime->IsTimeNull())
 						if ($this->blnAllowBlankTime)
 							$strMinuteListBox .= '<option value="">--</option>';
-					for ($intMinute = 0; $intMinute <= 59; $intMinute++) {
+					for ($intMinute = 0; $intMinute <= 59; $intMinute += $this->intMinuteInterval) {
 						if (!$dttDateTime->IsTimeNull() && ($dttDateTime->Minute == $intMinute))
 							$strSelected = ' selected="selected"';
 						else
@@ -303,7 +302,7 @@
 					if (!$this->blnRequired || $dttDateTime->IsTimeNull())
 						if ($this->blnAllowBlankTime)
 							$strSecondListBox .= '<option value="">--</option>';
-					for ($intSecond = 0; $intSecond <= 59; $intSecond++) {
+					for ($intSecond = 0; $intSecond <= 59; $intSecond  += $this->intSecondInterval) {
 						if (!$dttDateTime->IsTimeNull() && ($dttDateTime->Second == $intSecond))
 							$strSelected = ' selected="selected"';
 						else
@@ -319,9 +318,9 @@
 					// PUtting it all together
 					if (($this->strDateTimePickerType == QDateTimePickerType::DateTimeSeconds) ||
 						($this->strDateTimePickerType == QDateTimePickerType::TimeSeconds))
-						$strToReturn .= $strHourListBox . ':' . $strMinuteListBox . ':' . $strSecondListBox;
+						$strToReturn .= $strHourListBox . $this->strTimeSeparator . $strMinuteListBox . $this->strTimeSeparator . $strSecondListBox;
 					else
-						$strToReturn .= $strHourListBox . ':' . $strMinuteListBox;
+						$strToReturn .= $strHourListBox . $this->strTimeSeparator . $strMinuteListBox;
 			}
 
 			if ($this->strCssClass)

--- a/includes/base_controls/QDateTimePicker.class.php
+++ b/includes/base_controls/QDateTimePicker.class.php
@@ -15,8 +15,14 @@
 	 * @property mixed $DateTime
 	 * @property string $DateTimePickerType
 	 * @property string $DateTimePickerFormat
-	 * @property integer $MinimumYear
-	 * @property integer $MaximumYear
+	 * @property integer $MinimumYear Minimum Year to show
+	 * @property integer $MaximumYear Maximum Year to show
+	 * @property bool $AllowBlankTime Allow the '--' value for the Time section of control's UI
+	 * @property bool $AllowBlankDate Allow the '--' value for the Date section of control's UI
+	 * @property string $TimeSeparator Character to separate the select boxes for hour, minute and seconds
+	 * @property int $SecondInterval Seconds are shown in these intervals
+	 * @property int $MinuteInterval Minutes are shown in these intervals
+	 * @property int $HourInterval Hours are shown in these intervals
 	 */
 	class QDateTimePicker extends QControl {
 		///////////////////////////
@@ -34,6 +40,21 @@
 		protected $intSelectedMonth = null;
 		protected $intSelectedDay = null;
 		protected $intSelectedYear = null;
+
+		// CONSTRAINTS
+		/** @var bool Allow or Disallow Choosing '--' in the control UI for time */
+		protected $blnAllowBlankTime = true;
+		/** @var bool Allow or Disallow Choosing '--' in the control UI for date */
+		protected $blnAllowBlankDate = true;
+		/** @var bool The character which appears between the hour, minutes and seconds */
+		protected $strTimeSeparator = ':';
+		/** @var int Steps of intervals to show for second field */
+		protected $intSecondInterval = 1;
+		/** @var int Steps of intervals to show for minute field */
+		protected $intMinuteInterval = 1;
+		/** @var int Steps of intervals to show for hour field */
+		protected $intHourInterval = 1;
+
 
 		// SETTINGS
 		protected $strJavaScripts = 'date_time_picker.js';
@@ -56,30 +77,30 @@
 							$intMonth = $_POST[$strKey];
 						else
 							$intMonth = null;
-	
+
 						$strKey = $this->strControlId . '_lstDay';
 						if (array_key_exists($strKey, $_POST))
 							$intDay = $_POST[$strKey];
 						else
 							$intDay = null;
-	
+
 						$strKey = $this->strControlId . '_lstYear';
 						if (array_key_exists($strKey, $_POST))
 							$intYear = $_POST[$strKey];
 						else
 							$intYear = null;
-	
+
 						$this->intSelectedMonth = $intMonth;
 						$this->intSelectedDay = $intDay;
 						$this->intSelectedYear = $intYear;
-	
+
 						if (strlen($intYear) && strlen($intMonth) && strlen($intDay))
 							$dttNewDateTime->setDate($intYear, $intMonth, $intDay);
 						else
 							$dttNewDateTime->Year = null;
 						break;
 				}
-	
+
 				// Update Time Component
 				switch ($this->strDateTimePickerType) {
 					case QDateTimePickerType::Time:
@@ -96,7 +117,7 @@
 								if (($this->strDateTimePickerType == QDateTimePickerType::TimeSeconds) ||
 									($this->strDateTimePickerType == QDateTimePickerType::DateTimeSeconds))
 									$intSecond = $_POST[$this->strControlId . '_lstSecond'];
-	
+
 								if (strlen($intHour) && strlen($intMinute) && strlen($intSecond))
 									$dttNewDateTime->setTime($intHour, $intMinute, $intSecond);
 								else
@@ -105,7 +126,7 @@
 						}
 						break;
 				}
-	
+
 				// Update local intTimestamp
 				$this->dttDateTime = $dttNewDateTime;
 			}
@@ -140,7 +161,8 @@
 					// Month
 					$strMonthListbox = sprintf('<select name="%s_lstMonth" id="%s_lstMonth" class="month" %s%s>', $this->strControlId, $this->strControlId, $strAttributes, $strCommand);
 					if (!$this->blnRequired || $dttDateTime->IsDateNull())
-						$strMonthListbox .= '<option value="">--</option>';
+						if($this->blnAllowBlankDate)
+							$strMonthListbox .= '<option value="">--</option>';
 					for ($intMonth = 1; $intMonth <= 12; $intMonth++) {
 						if ((!$dttDateTime->IsDateNull() && ($dttDateTime->Month == $intMonth)) || ($this->intSelectedMonth == $intMonth))
 							$strSelected = ' selected="selected"';
@@ -156,7 +178,8 @@
 					// Day
 					$strDayListbox = sprintf('<select name="%s_lstDay" id="%s_lstDay" class="day" %s%s>', $this->strControlId, $this->strControlId, $strAttributes, $strCommand);
 					if (!$this->blnRequired || $dttDateTime->IsDateNull())
-						$strDayListbox .= '<option value="">--</option>';
+						if($this->blnAllowBlankDate)
+							$strDayListbox .= '<option value="">--</option>';
 					if ($dttDateTime->IsDateNull()) {
 						if ($this->blnRequired) {
 							// New DateTime, but we are required -- therefore, let's assume January is preselected
@@ -182,6 +205,7 @@
 								}
 							} else {
 								// It's ok just to have the "--" marks and nothing else
+								$strDayListbox .= '<option value="">--</option>';
 							}
 						}
 					} else {
@@ -202,7 +226,8 @@
 					// Year
 					$strYearListbox = sprintf('<select name="%s_lstYear" id="%s_lstYear" class="year" %s%s>', $this->strControlId, $this->strControlId, $strAttributes, $strCommand);
 					if (!$this->blnRequired || $dttDateTime->IsDateNull())
-						$strYearListbox .= '<option value="">--</option>';
+						if($this->blnAllowBlankDate)
+							$strYearListbox .= '<option value="">--</option>';
 					for ($intYear = $this->intMinimumYear; $intYear <= $this->intMaximumYear; $intYear++) {
 						if (/*!$dttDateTime->IsDateNull() && */(($dttDateTime->Year == $intYear) || ($this->intSelectedYear == $intYear)))
 							$strSelected = ' selected="selected"';
@@ -240,7 +265,8 @@
 					// Hour
 					$strHourListBox = sprintf('<select name="%s_lstHour" id="%s_lstHour" class="hour" %s>', $this->strControlId, $this->strControlId, $strAttributes);
 					if (!$this->blnRequired || $dttDateTime->IsTimeNull())
-						$strHourListBox .= '<option value="">--</option>';
+						if ($this->blnAllowBlankTime)
+							$strHourListBox .= '<option value="">--</option>';
 					for ($intHour = 0; $intHour <= 23; $intHour++) {
 						if (!$dttDateTime->IsTimeNull() && ($dttDateTime->Hour == $intHour))
 							$strSelected = ' selected="selected"';
@@ -257,7 +283,8 @@
 					// Minute
 					$strMinuteListBox = sprintf('<select name="%s_lstMinute" id="%s_lstMinute" class="minute" %s>', $this->strControlId, $this->strControlId, $strAttributes);
 					if (!$this->blnRequired || $dttDateTime->IsTimeNull())
-						$strMinuteListBox .= '<option value="">--</option>';
+						if ($this->blnAllowBlankTime)
+							$strMinuteListBox .= '<option value="">--</option>';
 					for ($intMinute = 0; $intMinute <= 59; $intMinute++) {
 						if (!$dttDateTime->IsTimeNull() && ($dttDateTime->Minute == $intMinute))
 							$strSelected = ' selected="selected"';
@@ -274,7 +301,8 @@
 					// Seconds
 					$strSecondListBox = sprintf('<select name="%s_lstSecond" id="%s_lstSecond" class="second" %s>', $this->strControlId, $this->strControlId, $strAttributes);
 					if (!$this->blnRequired || $dttDateTime->IsTimeNull())
-						$strSecondListBox .= '<option value="">--</option>';
+						if ($this->blnAllowBlankTime)
+							$strSecondListBox .= '<option value="">--</option>';
 					for ($intSecond = 0; $intSecond <= 59; $intSecond++) {
 						if (!$dttDateTime->IsTimeNull() && ($dttDateTime->Second == $intSecond))
 							$strSelected = ' selected="selected"';
@@ -311,12 +339,12 @@
 					$blnIsNull = true;
 				else {
 					if ((($this->strDateTimePickerType == QDateTimePickerType::Date) ||
-						($this->strDateTimePickerType == QDateTimePickerType::DateTime) ||
-						($this->strDateTimePickerType == QDateTimePickerType::DateTimeSeconds )) && 
+							($this->strDateTimePickerType == QDateTimePickerType::DateTime) ||
+							($this->strDateTimePickerType == QDateTimePickerType::DateTimeSeconds )) &&
 						($this->dttDateTime->IsDateNull()))
 						$blnIsNull = true;
 					else if ((($this->strDateTimePickerType == QDateTimePickerType::Time) ||
-						($this->strDateTimePickerType == QDateTimePickerType::TimeSeconds)) &&
+							($this->strDateTimePickerType == QDateTimePickerType::TimeSeconds)) &&
 						($this->dttDateTime->IsTimeNull()))
 						$blnIsNull = true;
 				}
@@ -330,8 +358,8 @@
 				}
 			} else {
 				if ((($this->strDateTimePickerType == QDateTimePickerType::Date) ||
-					($this->strDateTimePickerType == QDateTimePickerType::DateTime) ||
-					($this->strDateTimePickerType == QDateTimePickerType::DateTimeSeconds )) &&
+						($this->strDateTimePickerType == QDateTimePickerType::DateTime) ||
+						($this->strDateTimePickerType == QDateTimePickerType::DateTimeSeconds )) &&
 					($this->intSelectedDay || $this->intSelectedMonth || $this->intSelectedYear) &&
 					($this->dttDateTime->IsDateNull())) {
 					$this->ValidationError = QApplication::Translate('Invalid Date');
@@ -360,6 +388,12 @@
 				case "DateTimePickerFormat": return $this->strDateTimePickerFormat;
 				case "MinimumYear": return $this->intMinimumYear;
 				case "MaximumYear": return $this->intMaximumYear;
+				case "AllowBlankTime": return $this->blnAllowBlankTime;
+				case "AllowBlankDate": return $this->blnAllowBlankDate;
+				case "TimeSeparator": return $this->strTimeSeparator;
+				case "SecondInterval": return $this->intSecondInterval;
+				case "MinuteInterval": return $this->intMinuteInterval;
+				case "HourInterval": return $this->intHourInterval;
 
 				default:
 					try {
@@ -428,6 +462,59 @@
 				case "MaximumYear":
 					try {
 						$this->intMaximumYear = QType::Cast($mixValue, QType::String);
+					} catch (QInvalidCastException $objExc) {
+						$objExc->IncrementOffset();
+						throw $objExc;
+					}
+					break;
+				case "AllowBlankTime":
+					try {
+						$this->blnAllowBlankTime = QType::Cast($mixValue, QType::Boolean);
+					} catch (QInvalidCastException $objExc) {
+						$objExc->IncrementOffset();
+						throw $objExc;
+					}
+					break;
+
+				case "AllowBlankDate":
+					try {
+						$this->blnAllowBlankDate = QType::Cast($mixValue, QType::Boolean);
+					} catch (QInvalidCastException $objExc) {
+						$objExc->IncrementOffset();
+						throw $objExc;
+					}
+					break;
+
+				case "TimeSeparator":
+					try {
+						$this->strTimeSeparator = QType::Cast($mixValue, QType::String);
+					} catch (QInvalidCastException $objExc) {
+						$objExc->IncrementOffset();
+						throw $objExc;
+					}
+					break;
+
+				case "SecondInterval":
+					try {
+						$this->intSecondInterval = QType::Cast($mixValue, QType::Integer);
+					} catch (QInvalidCastException $objExc) {
+						$objExc->IncrementOffset();
+						throw $objExc;
+					}
+					break;
+
+				case "MinuteInterval":
+					try {
+						$this->intMinuteInterval = QType::Cast($mixValue, QType::Integer);
+					} catch (QInvalidCastException $objExc) {
+						$objExc->IncrementOffset();
+						throw $objExc;
+					}
+					break;
+
+				case "HourInterval":
+					try {
+						$this->intHourInterval = QType::Cast($mixValue, QType::Integer);
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
 						throw $objExc;


### PR DESCRIPTION
Added the AllowBlankTime, AllowBlankDate, TimeSeparator, SecondInterval, MinuteInterval and HourInterval property.

**AllowBlankTime** and **AllowBlankDate** can be used to remove the ```--``` entry from the DateTimePicker. This is helpful where we have to force the user to enter valid time. 

**TimeSeparator** allows you to select the character used for separate time.

**HourInterval**, **MinuteInterval** and **SecondInterval** allow the developer to select intervals that he wants to let the user select from (e.g. I want to allow selection of time only in intervals of 10 minutes).

These properties allow us to escape a lot of validation logic at times when extreme strictness is not required but certain rules (which are obvious by these properties) are helpful.