### PR TITLE
Restoring DeleteCache method to the generated ORM classes.

### DIFF
--- a/includes/codegen/templates/db_orm/class_gen/object_delete.tpl.php
+++ b/includes/codegen/templates/db_orm/class_gen/object_delete.tpl.php
@@ -60,6 +60,17 @@
 
 		}
 
+        /**
+ 	     * Delete this <?php echo $objTable->ClassName ?> ONLY from the cache
+ 		 * @return void
+		 */
+		public function DeleteCache() {
+			if (QApplication::$objCacheProvider && QApplication::$Database[<?php echo $objCodeGen->DatabaseIndex; ?>]->Caching) {
+				$strCacheKey = QApplication::$objCacheProvider->CreateKey(QApplication::$Database[<?php echo $objCodeGen->DatabaseIndex; ?>]->Database, '<?php echo $objTable->ClassName ?>', <?php echo $objCodeGen->ImplodeObjectArray(', ', '$this->', '', 'VariableName', $objTable->PrimaryKeyColumnArray); ?>);
+				QApplication::$objCacheProvider->Delete($strCacheKey);
+			}
+		}
+
 		/**
 		 * Delete all <?= $objTable->ClassNamePlural ?>
 


### PR DESCRIPTION
In the current Beta 3.0 branch, the templates do not have the DeleteCache method which makes the programs fail. This pull request is to bring it back. 