### PR TITLE
bugfix-EmptyCheckLists2

### DIFF
--- a/assets/js/qcubed.js
+++ b/assets/js/qcubed.js
@@ -305,7 +305,7 @@ qcubed = {
 
         $j.each(nullArrays, function(key, val) {
             if (val) {
-                strPostData += "&" + key;   // add a null value for the array
+                strPostData += "&" + key + '=';   // add a null value for the array
             }
         });
         qcubed.ajaxError = false;


### PR DESCRIPTION
Follow up to bugfix-EmptyCheckLists.
Some versions of PHP do not send a variable with no '=' sign to the $_POST array. This fixes that.