### PR TITLE
bugfix-PluginManager

### DIFF
--- a/assets/php/_devtools/plugin_manager.php
+++ b/assets/php/_devtools/plugin_manager.php
@@ -16,8 +16,8 @@
 
 		protected function Form_Create() {
 			$this->dtgPlugins_Create();
-			$this->btnNewPlugin_Create();
-			$this->dlgUpload_Create();
+			//$this->btnNewPlugin_Create();
+			//$this->dlgUpload_Create();
 		}
 				
 		private function btnNewPlugin_Create() {
@@ -25,10 +25,10 @@
 			$this->btnNewPlugin->Text = "Install a New Plugin";
 			$this->btnNewPlugin->AddAction(new QClickEvent(), new QAjaxAction('btnNewPlugin_Click'));
 		}
-		
+		/*
 		public function btnNewPlugin_Click() {
 			$this->dlgUpload->ShowDialogBox();
-		}
+		}*/
 		
 		private function dtgPlugins_Create() {
 			$this->dtgPlugins = new QDataGrid($this, 'dtgPlugins');
@@ -107,7 +107,7 @@
 			}
 			return null;
 		}
-		
+		/*
 		private function dlgUpload_Create() {
 			$this->dlgUpload = new QFileAssetDialog($this, 'dlgUpload_done');
 			$this->dlgUpload->Title = "Install a New Plugin";
@@ -137,7 +137,8 @@
 			}
 			
 			QApplication::Redirect('plugin_edit.php?strType=new&strName=' . $pluginFolder);
-		}		
+		}
+		*/
 	}	
 
 	PluginManagerForm::Run('PluginManagerForm');

--- a/assets/php/_devtools/plugin_manager.tpl.php
+++ b/assets/php/_devtools/plugin_manager.tpl.php
@@ -4,19 +4,14 @@
 ?>
 	<h1><?php _t('Plugin Manager'); ?></h1>
 		<?php $this->RenderBegin() ?>
-	<p> QCubed uses Composer to install plugins. To install a plugin, simply require it
-	   in your list of files in your root composer.json file, then execute the Composer 
-	   install command.
+	<p> QCubed uses Composer to install plugins. To install a plugin, simply execute the 'composer require plugin_name' command on your command line.
 	</p>
+	<p>Below is a list of your currently installed plugins.</p>
 	<?php $this->dtgPlugins->Render(); ?>
 	
 	<hr />
 	
-	<p><a target="_blank" href="<?= QPluginInstaller::ONLINE_PLUGIN_REPOSITORY ?>">
-	Online repository of QCubed plugins</a></p>
-	
-	<?php $this->dlgUpload->Render(); ?>
-	
+
 	<?php $this->RenderEnd() ?>
 	
 <?php require(__CONFIGURATION__ . '/footer.inc.php'); ?>


### PR DESCRIPTION
Completing the removal of the old installer. 

Commented out old code instead of removing it. Potentially the installer could be reworked to directly call the composer command, but its not so easy because people can set up composer in different ways. We somehow have to capture how the user executes the composer command in order to automate the process. Or, we call into github using the github api and bypass composer.