### PR TITLE
feature-TypeTableReference

### DIFF
--- a/includes/codegen/templates/db_orm/class_gen/property_get.tpl.php
+++ b/includes/codegen/templates/db_orm/class_gen/property_get.tpl.php
@@ -26,7 +26,8 @@
 				// Member Objects
 				///////////////////
 <?php foreach ($objTable->ColumnArray as $objColumn) { ?>
-<?php if (($objColumn->Reference) && (!$objColumn->Reference->IsType)) { ?>
+<?php if ($objColumn->Reference) { ?>
+<?php if (!$objColumn->Reference->IsType) { ?>
 				case '<?= $objColumn->Reference->PropertyName ?>':
 					/**
 					 * Gets the value for the <?= $objColumn->Reference->VariableType ?> object referenced by <?= $objColumn->VariableName ?> <?php if ($objColumn->Identity) print '(Read-Only PK)'; else if ($objColumn->PrimaryKey) print '(PK)'; else if ($objColumn->Unique) print '(Unique)'; else if ($objColumn->NotNull) print '(Not Null)'; ?>
@@ -42,7 +43,19 @@
 						$objExc->IncrementOffset();
 						throw $objExc;
 					}
+<?php } else { // type ?>
+				case '<?= $objColumn->Reference->PropertyName ?>':
+					/**
+					 * Gets the value for the <?= $objColumn->Reference->VariableType ?> type referenced by <?= $objColumn->VariableName ?>
+					 * @return string
+					 */
+					if ($this-><?= $objColumn->VariableName ?>) {
+						return <?= $objColumn->Reference->VariableType ?>::ToString($this-><?= $objColumn->VariableName ?>);
+					} else {
+						return '';
+					}
 
+<?php } ?>
 <?php } ?>
 <?php } ?>
 <?php foreach ($objTable->ReverseReferenceArray as $objReverseReference) { ?>

--- a/includes/codegen/templates/db_orm/class_gen/qcubed_query_classes.tpl.php
+++ b/includes/codegen/templates/db_orm/class_gen/qcubed_query_classes.tpl.php
@@ -76,7 +76,7 @@
 <?php foreach ($objTable->ColumnArray as $objColumn) { ?>
 				case '<?= $objColumn->PropertyName ?>':
 					return new QQNode('<?= $objColumn->Name ?>', '<?= $objColumn->PropertyName ?>', '<?= $objColumn->DbType ?>', $this);
-<?php if (($objColumn->Reference) && (!$objColumn->Reference->IsType)) { ?>
+<?php if ($objColumn->Reference) { ?>
 				case '<?= $objColumn->Reference->PropertyName ?>':
 					return new QQNode<?= $objColumn->Reference->VariableType; ?>('<?= $objColumn->Name ?>', '<?= $objColumn->Reference->PropertyName ?>', '<?= $objColumn->DbType ?>', $this);
 <?php } ?>


### PR DESCRIPTION
Allowing references to type tables to be directly accessed through the referencing tables. This will permit type tables to more easily be displayed in datagrids, and save typing when trying to get the value of a type. 