### PR TITLE
bugfix-FormDraftsLocation

### DIFF
--- a/assets/php/_devtools/start_page.php
+++ b/assets/php/_devtools/start_page.php
@@ -20,12 +20,12 @@
 	<ul class="link-list">
 		<li><a href="<?php _p(__VIRTUAL_DIRECTORY__ . __DEVTOOLS_ASSETS__) ?>/codegen.php">Code Generator</a> - to create ORM model objects that map to tables in your database, and ModelConnectors
 			and form drafts to edit and display the data.</li>
-		<li><a href="<?php _p(__VIRTUAL_DIRECTORY__ . __FORM_DRAFTS__) ?>/index.php">View Form Drafts</a> - to view the generated files (after you run the Code Generator).</li>
+		<li><a href="<?php _p(__VIRTUAL_DIRECTORY__ . __DEVTOOLS_ASSETS__) ?>/form_drafts.php">View Form Drafts</a> - to view the generated files (after you run the Code Generator).</li>
 		<li><a href="<?php _p(__VIRTUAL_DIRECTORY__ . __EXAMPLES__) ?>/index.php">QCubed Examples</a> - learn QCubed by studying and modifying the example files locally.</li>
 		<li><a href="<?php _p(__VIRTUAL_DIRECTORY__ . __DEVTOOLS_ASSETS__) ?>/plugin_manager.php">Plugin Manager</a> - to extend QCubed with community-contributed plugins.</li>
 		<li><a href="<?php _p(__VIRTUAL_DIRECTORY__ . __DEVTOOLS_ASSETS__) ?>/update_checker.php">Update Checker</a> - check for updates for QCubed core and plugins.</li>
 		<li><a href="<?php _p(__VIRTUAL_DIRECTORY__ . __PHP_ASSETS__) ?>/qcubed_unit_tests.php">QCubed Unit Tests</a> - set of tests that QCubed developers use to verify the integrity of the framework.
-			You must install the test SQL database and codgen_options.json file to run the tests. These can be found in the <?php _p(__VIRTUAL_DIRECTORY__ . __PHP_ASSETS__ . '/examples')?> directory.</li>
+			You must install the test SQL database and codegen_options.json file to run the tests. These can be found in the <?php _p(__VIRTUAL_DIRECTORY__ . __PHP_ASSETS__ . '/examples')?> directory.</li>
 	</ul>
 <?php if (!QApplication::IsRemoteAdminSession()) { ?>
 	<pre><code><?php QApplication::VarDump(); ?></code></pre>


### PR DESCRIPTION
Refering to the form_drafts in dev-tools so that when you need to recreate the entire directory, you don't have to select out the index.php file in there.