### PR TITLE
feature-QControlProxyImprovements

### DIFF
--- a/assets/php/examples/advanced_ajax/CalculatorWidget.tpl.php
+++ b/assets/php/examples/advanced_ajax/CalculatorWidget.tpl.php
@@ -2,28 +2,28 @@
 <table>
 	<tr>
 		<td colspan="3"><?php $_CONTROL->btnUpdate->Render('CssClass=calculator_top_button'); ?> <?php $_CONTROL->btnCancel->Render('CssClass=calculator_top_button'); ?></td>
-		<td><input type="button" value="/" class="calculator_button" <?php $_CONTROL->pxyOperationControl->RenderAsEvents('/'); ?>/></td>
+		<td><?= $this->pxyOperationControl->RenderAsButton('/', '/', ['class'=>"calculator_button"]); ?></td>
 	</tr>
 	<tr>
-		<td><input type="button" value="7" class="calculator_button" <?php $_CONTROL->pxyNumberControl->RenderAsEvents(7); ?>/></td>
-		<td><input type="button" value="8" class="calculator_button" <?php $_CONTROL->pxyNumberControl->RenderAsEvents(8); ?>/></td>
-		<td><input type="button" value="9" class="calculator_button" <?php $_CONTROL->pxyNumberControl->RenderAsEvents(9); ?>/></td>
-		<td><input type="button" value="*" class="calculator_button" <?php $_CONTROL->pxyOperationControl->RenderAsEvents('*'); ?>/></td>
+		<td><?= $this->pxyNumberControl->RenderAsButton('7', 7, ['class'=>"calculator_button"]); ?></td>
+		<td><?= $this->pxyNumberControl->RenderAsButton('8', 8, ['class'=>"calculator_button"]); ?></td>
+		<td><?= $this->pxyNumberControl->RenderAsButton('9', 9, ['class'=>"calculator_button"]); ?></td>
+		<td><?= $this->pxyOperationControl->RenderAsButton('*', '*', ['class'=>"calculator_button"]); ?></td>
 	</tr>
 	<tr>
-		<td><input type="button" value="4" class="calculator_button" <?php $_CONTROL->pxyNumberControl->RenderAsEvents(4); ?>/></td>
-		<td><input type="button" value="5" class="calculator_button" <?php $_CONTROL->pxyNumberControl->RenderAsEvents(5); ?>/></td>
-		<td><input type="button" value="6" class="calculator_button" <?php $_CONTROL->pxyNumberControl->RenderAsEvents(6); ?>/></td>
-		<td><input type="button" value="-" class="calculator_button" <?php $_CONTROL->pxyOperationControl->RenderAsEvents('-'); ?>/></td>
+		<td><?= $this->pxyNumberControl->RenderAsButton('4', 4, ['class'=>"calculator_button"]); ?></td>
+		<td><?= $this->pxyNumberControl->RenderAsButton('5', 5, ['class'=>"calculator_button"]); ?></td>
+		<td><?= $this->pxyNumberControl->RenderAsButton('6', 6, ['class'=>"calculator_button"]); ?></td>
+		<td><?= $this->pxyOperationControl->RenderAsButton('-', '-', ['class'=>"calculator_button"]); ?></td>
 	</tr>
 	<tr>
-		<td><input type="button" value="1" class="calculator_button" <?php $_CONTROL->pxyNumberControl->RenderAsEvents(1); ?>/></td>
-		<td><input type="button" value="2" class="calculator_button" <?php $_CONTROL->pxyNumberControl->RenderAsEvents(2); ?>/></td>
-		<td><input type="button" value="3" class="calculator_button" <?php $_CONTROL->pxyNumberControl->RenderAsEvents(3); ?>/></td>
-		<td><input type="button" value="+" class="calculator_button" <?php $_CONTROL->pxyOperationControl->RenderAsEvents('+'); ?>/></td>
+		<td><?= $this->pxyNumberControl->RenderAsButton('1', 1, ['class'=>"calculator_button"]); ?></td>
+		<td><?= $this->pxyNumberControl->RenderAsButton('2', 2, ['class'=>"calculator_button"]); ?></td>
+		<td><?= $this->pxyNumberControl->RenderAsButton('3', 3, ['class'=>"calculator_button"]); ?></td>
+		<td><?= $this->pxyOperationControl->RenderAsButton('+', '+', ['class'=>"calculator_button"]); ?></td>
 	</tr>
 	<tr>
-		<td><input type="button" value="0" class="calculator_button" <?php $_CONTROL->pxyNumberControl->RenderAsEvents(0); ?>/></td>
+		<td><input type="button" value="0" class="calculator_button" <?php $_CONTROL->pxyNumberControl->RenderAttributes(0); ?>/></td>
 		<td><?php $_CONTROL->btnPoint->Render('CssClass=calculator_button'); ?></td>
 		<td><?php $_CONTROL->btnClear->Render('CssClass=calculator_button'); ?></td>
 		<td><?php $_CONTROL->btnEqual->Render('CssClass=calculator_button'); ?></td>

--- a/assets/php/examples/dynamic/control_proxy.tpl.php
+++ b/assets/php/examples/dynamic/control_proxy.tpl.php
@@ -5,34 +5,37 @@
 	<h1>Using a QControlProxy to Receive Events</h1>
 
 	<p>Sometimes you may want to create buttons, links or other HTML items which can "trigger" a Server or Ajax
-		action without actually creating a control.  The typical example of this is if you want to dynamically
+		action without actually creating a QControl.  The typical example of this is if you want to dynamically
 		create a large number of links or buttons (e.g. in a <strong>QDataGrid</strong> or <strong>QDataRepeater</strong>) which would trigger
 		an action, but because the link/button doesn't have any other state (e.g. you'll never want to
 		change its value or style, or you're comfortable doing this in pure javascript), you don't want to
 		incur the overhead of creating a whole <strong>QControl</strong> for each of these links or buttons.</p>
 
-	<p>The way you can do this is by creating a <strong>QControlProxy</strong> on your <strong>QForm</strong>, and having
-		any manually created links or buttons make hard-coded <strong>RenderAsEvents()</strong> method calls to
-		trigger your action/event.</p>
+	<p>The way you can do this is by creating a <strong>QControlProxy</strong> on your <strong>QForm</strong>, and attaching
+		it to a link, button or other html item by rendering it specially.</p>
 
 	<p>The example below illustrates the manual creation (see the code for more information) of a list of
-		links which makes use of a single <strong>QControlProxy</strong> to trigger our event.  Notice that while there are 4 links
-		and 4 buttons which each trigger Ajax-based Actions, there is actually only 1 <strong>QControl</strong> (which of course is
-		the <strong>QControlProxy</strong> control itself) defined to handle all these events.</p>
+		links which makes use of a single <strong>QControlProxy</strong> to trigger our event.  Notice that while there are many links
+		and buttons which each trigger Ajax-based Actions, there is actually only 1 <strong>QControlProxy</strong>
+		defined to handle all these events.</p>
 </div>
 
 <div id="demoZone">
-	<h2>These A HREF links can take advantage of <em>all</em> Events defined on our proxy control by using RenderAsEvents...</h2>
-	<p><a href="#baz" <?php $this->pxyExample->RenderAsEvents('Baz'); ?>">Baz</a> |
-		<a href="#foo" <?php $this->pxyExample->RenderAsEvents('Foo'); ?>">Foo</a> |
-		<a href="#blah" <?php $this->pxyExample->RenderAsEvents('Blah'); ?>">Blah</a> |
-		<a href="#test" <?php $this->pxyExample->RenderAsEvents('Test'); ?>">Test</a></p>
+	<p><em>QControlProxy</em>s can be rendered as links...</p>
+	<p><?= $this->pxyExample->RenderAsLink('Baz', 'Baz'); ?> |
+		<?= $this->pxyExample->RenderAsLink('Foo', 'Foo'); ?> |
+		<?= $this->pxyExample->RenderAsLink('Blah', 'Blah'); ?> |
+		<?= $this->pxyExample->RenderAsLink('Test', 'Test'); ?></p>
+	<p>Or buttons...</p>
+	<p><?= $this->pxyExample->RenderAsButton('Baz', 'Baz'); ?> |
+		<?= $this->pxyExample->RenderAsButton('Foo', 'Foo'); ?> |
+		<?= $this->pxyExample->RenderAsButton('Blah', 'Blah'); ?> |
+		<?= $this->pxyExample->RenderAsButton('Test', 'Test'); ?></p>
 
-	<h3>Same goes for any other HTML element, like buttons...</h3>
-	<p><input type="button" <?php $this->pxyExample->RenderAsEvents('Test 1') ?> value="Test #1"> |
-		<input type="button" <?php $this->pxyExample->RenderAsEvents('Test 2') ?> value="Test #2"> |
-		<input type="button" <?php $this->pxyExample->RenderAsEvents('Test 3') ?> value="Test #3"> |
-		<input type="button" <?php $this->pxyExample->RenderAsEvents('Test 4') ?> value="Test #4"></p>
+	<p>Or embedded in any kind of tag.<p>
+	<p><input type="checkbox" <?= $this->pxyExample->RenderAttributes('Test 1') ?> > |
+		<span <?= $this->pxyExample->RenderAttributes('Test 2') ?> >Test 2</span>  |
+		<input type="radio" <?= $this->pxyExample->RenderAttributes('Test 3') ?> >
 
 	<?php $this->lblMessage->Render(); ?>
 	<?php $this->pnlHover->Render(); ?>

--- a/assets/php/examples/events_actions/event_delegation.php
+++ b/assets/php/examples/events_actions/event_delegation.php
@@ -183,7 +183,7 @@
 		 * @return String
 		 */
 		public function RenderDeleteButton($objPerson) {
-			return '<button ' . $this->pxyDelete->RenderAsEvents($objPerson->Id,false,"delete_".$objPerson->Id) . '>Delete</button>';
+			return $this->pxyDelete->RenderAsButton('Delete', "delete_".$objPerson->Id);
 		}
 		
 		/**

--- a/assets/php/examples/other/datagrid_connectors.php
+++ b/assets/php/examples/other/datagrid_connectors.php
@@ -53,7 +53,7 @@ class ExamplesForm extends QForm {
 		$this->pxyExample = new QControlProxy($this);
 		$this->pxyExample->AddAction(new QClickEvent(), new QAjaxAction('pxyExample_Click'));
 
-		// FInally, there are even Connector methods to add an Edit Button column
+		// Finally, there are even Connector methods to add an Edit Button column
 		$this->dtgProjects->AddEditProxyColumn($this->pxyExample, 'Click Me', 'Faux Edit Column');
 	}
 

--- a/includes/base_controls/QControlBase.class.php
+++ b/includes/base_controls/QControlBase.class.php
@@ -59,8 +59,9 @@
 	 *   Show and hide are much faster.
 	 *
 	 * @package Controls
-	 * 
-	 * @property boolean $ActionsMustTerminate Prevent the default action from happenning upon an event trigger. See documentation for "protected $blnActionsMustTerminate" below.
+	 *
+	 * @property-read boolean $ActionsMustTerminate Prevent the default action from happenning upon an event trigger. See documentation for "protected $blnActionsMustTerminate" below.
+	 * @property-read boolean $ScriptsOnly Whether the control only generates javascripts and not html.
 	 * @property mixed $ActionParameter This property allows you to pass your own parameters to the handlers for actions applied to this control.
 	 *			 this can be a string or an object of type QJsClosure. If you pass in a QJsClosure it is possible to return javascript objects/arrays 
 	 *			 when using an ajax or server action.
@@ -207,6 +208,8 @@
 		 * Modification of this variable is to be done by using 'ActionMustTerminate' property exposed as a property
 		 */
 		protected $blnActionsMustTerminate = false;
+		/** @var bool True if this control only generates javascripts and not html. */
+		protected $blnScriptsOnly = false;
 		/** @var bool Is this control a block type element? This determines whether the control will be wrapped in
 		 *  a div or a span if blnUseWrapper is true. For example, if */
 		protected $blnIsBlockElement = false;
@@ -896,8 +899,9 @@
 		 */
 		public function RenderActionScripts() {
 			$strToReturn = '';
-			foreach ($this->objActionArray as $strEventName => $objActions)
+			foreach ($this->objActionArray as $strEventName => $objActions) {
 				$strToReturn .= $this->GetJavaScriptForEvent($strEventName);
+			}
 			return $strToReturn;
 		}
 
@@ -1895,6 +1899,7 @@
 				case "WrapperModified": return $this->blnWrapperModified;
 				case "ActionParameter": return $this->mixActionParameter;
 				case "ActionsMustTerminate": return $this->blnActionsMustTerminate;
+				case "ScriptsOnly": return $this->blnScriptsOnly;
 				case "WrapperCssClass": return $this->GetWrapperStyler()->CssClass;
 				case "UseWrapper": return $this->blnUseWrapper;
 

--- a/includes/base_controls/QControlProxy.class.php
+++ b/includes/base_controls/QControlProxy.class.php
@@ -37,12 +37,14 @@
 		 * @param string $strTag					Tag to use. Defaults to 'a'.
 		 * @return string
 		 */
-		public function RenderLink($strLabel, $strActionParameter = null, $attributes = null, $strTag = 'a') {
-			$attributes['href'] = '#';
-			$attributes['data-qpxy'] = $this->strControlId;
+		public function RenderAsLink($strLabel, $strActionParameter = null, $attributes = [], $strTag = 'a') {
+			$defaults['href'] = '#';
+			$defaults['data-qpxy'] = $this->strControlId;
 			if ($strActionParameter) {
-				$attributes['data-qap'] = $strActionParameter;
+				$defaults['data-qap'] = $strActionParameter;
 			}
+			$attributes = array_merge($defaults, $attributes); // will only apply defaults that are not in attributes
+
 			$strLabel = QApplication::HtmlEntities($strLabel);
 
 			return QHtml::RenderTag($strTag, $attributes, $strLabel);
@@ -53,12 +55,14 @@
 		 *
 		 * @param string $strLabel					Text to link to
 		 * @param string|null $strActionParameter	Action parameter for this rendering of the control. Will be sent to the ActionParameter of the action.
-		 * @param null|array $attributes			Array of attributes to add to the tag for the link.
+		 * @param array $attributes			Array of attributes to add to the tag for the link.
 		 * @return string
 		 */
-		public function RenderButton($strLabel, $strActionParameter = null, $attributes = null) {
-			$attributes['onclick']='return false';
-			return $this->RenderLink($strLabel, $strActionParameter, $attributes, 'button');
+		public function RenderAsButton($strLabel, $strActionParameter = null, $attributes = []) {
+			$defaults['onclick']='return false';
+			$defaults['type']='button';
+			$attributes = array_merge($defaults, $attributes); // will only apply defaults that are not in attributes
+			return $this->RenderAsLink($strLabel, $strActionParameter, $attributes, 'button');
 		}
 
 		/**
@@ -85,13 +89,14 @@
 		 * @param bool        $blnDisplayOutput   Should the output be sent to browser (true) or returned (false)
 		 * @param null        $strTargetControlId ID to be sent to the browser for this proxy's HTML element
 		 *
-		 * @deprecated		 Obsolete. Above methods generate less code and are easier to use.
+		 * @deprecated		 Obsolete. Above methods generate less code and are easier to use. Also, do not mix the two.
 		 *
 		 * @param bool        $blnRenderControlId Control ID to be rendered or not
 		 *
 		 * @return string
 		 */
 		public function RenderAsEvents($strActionParameter = null, $blnDisplayOutput = true, $strTargetControlId = null, $blnRenderControlId = true) {
+			$this->RenderAttributes();
 			if ($strTargetControlId)
 				$this->strTargetControlId = $strTargetControlId;
 			else

--- a/includes/base_controls/QControlProxy.class.php
+++ b/includes/base_controls/QControlProxy.class.php
@@ -7,12 +7,74 @@
 	 * Class QControlProxy is used to 'proxy' the actions for another control
 	 */
 	class QControlProxy extends QControl {
-		/** @var string HTML element ID which is to be rendered/sent to the browser */
+		/**
+		 * @var string HTML element ID which is to be rendered/sent to the browser
+		 * @deprecated This is not needed by newer implementation which uses HTML5 data tags.
+		 */
 		protected $strTargetControlId;
-		
+
+		/** @var bool Overriding parent class */
+		protected $blnActionsMustTerminate = true;
+		/** @var bool Overriding parent class */
+		protected $blnScriptsOnly = true;
+
+
+		public function __construct ($objParent, $strControlId = null) {
+			parent::__construct($objParent, $strControlId);
+			$this->mixActionParameter = new QJsClosure('return $j(this).data("qap")');
+		}
+
 		public function GetControlHtml() {
 			throw new QCallerException('QControlProxies cannot be rendered.  Use RenderAsEvents() within an HTML tag.');
 		}
+
+		/**
+		 * Render as an HTML link (anchor tag)
+		 *
+		 * @param string $strLabel					Text to link to
+		 * @param string|null $strActionParameter	Action parameter for this rendering of the control. Will be sent to the ActionParameter of the action.
+		 * @param null|array $attributes			Array of attributes to add to the tag for the link.
+		 * @param string $strTag					Tag to use. Defaults to 'a'.
+		 * @return string
+		 */
+		public function RenderLink($strLabel, $strActionParameter = null, $attributes = null, $strTag = 'a') {
+			$attributes['href'] = '#';
+			$attributes['data-qpxy'] = $this->strControlId;
+			if ($strActionParameter) {
+				$attributes['data-qap'] = $strActionParameter;
+			}
+			$strLabel = QApplication::HtmlEntities($strLabel);
+
+			return QHtml::RenderTag($strTag, $attributes, $strLabel);
+		}
+
+		/**
+		 * Render as an HTML button.
+		 *
+		 * @param string $strLabel					Text to link to
+		 * @param string|null $strActionParameter	Action parameter for this rendering of the control. Will be sent to the ActionParameter of the action.
+		 * @param null|array $attributes			Array of attributes to add to the tag for the link.
+		 * @return string
+		 */
+		public function RenderButton($strLabel, $strActionParameter = null, $attributes = null) {
+			$attributes['onclick']='return false';
+			return $this->RenderLink($strLabel, $strActionParameter, $attributes, 'button');
+		}
+
+		/**
+		 * Render just attributes that can be included in any html tag to attach the proxy to the tag.
+		 *
+		 * @param string|null $strActionParameter
+		 * @return string
+		 */
+		public function RenderAttributes($strActionParameter = null) {
+			$attributes['data-qpxy'] = $this->ControlId;
+			if ($strActionParameter) {
+				$attributes['data-qap'] = $strActionParameter;
+			}
+			return QHtml::RenderHtmlAttributes($attributes);
+		}
+
 
 		/**
 		 * Renders only the id of this Proxy essentially embedding it into (disguising it as) another element.
@@ -22,6 +84,9 @@
 		 * @param null|string $strActionParameter Action parameter against which the action will be taken $strActionParameter
 		 * @param bool        $blnDisplayOutput   Should the output be sent to browser (true) or returned (false)
 		 * @param null        $strTargetControlId ID to be sent to the browser for this proxy's HTML element
+		 *
+		 * @deprecated		 Obsolete. Above methods generate less code and are easier to use.
+		 *
 		 * @param bool        $blnRenderControlId Control ID to be rendered or not
 		 *
 		 * @return string
@@ -53,6 +118,8 @@
 		 * @param null|string $strActionParameter Action parameter against which the action will be taken
 		 * @param bool        $blnDisplayOutput   Should the output be sent to browser (true) or returned (false)
 		 * @param null|string $strTargetControlId ID to be sent to the browser for this proxy's HTML element
+		 *
+		 * @deprecated	From v2. Above ways are more efficient.
 		 *
 		 * @return string
 		 */
@@ -113,7 +180,8 @@
 		 */
 		public function __get($strName) {
 			switch ($strName) {
-				
+
+				// deprecated
 				case 'TargetControlId': return $this->strTargetControlId;
 				
 				default:
@@ -139,7 +207,8 @@
 			$this->blnModified = true;
 
 			switch ($strName) {
-				
+
+				// Deprecated
 				case 'TargetControlId': 
 					try {
 						return ($this->strTargetControlId = QType::Cast($mixValue, QType::String));

--- a/includes/base_controls/QFormBase.class.php
+++ b/includes/base_controls/QFormBase.class.php
@@ -1680,7 +1680,7 @@
 
 			// Go through all controls and gather up any JS or CSS to run or Form Attributes to modify
 			foreach ($this->GetAllControls() as $objControl) {
-				if ($objControl->Rendered) {
+				if ($objControl->Rendered || $objControl->ScriptsOnly) {
 					$strControlIdToRegister[] = $objControl->ControlId;
 
 					/* Note: GetEndScript may cause the control to register additional commands, or even add javascripts, so those should be handled after this. */

--- a/includes/base_controls/QPaginatorBase.class.php
+++ b/includes/base_controls/QPaginatorBase.class.php
@@ -120,11 +120,13 @@
 				$strPrevious = $this->strLabelForPrevious;
 			} else {
 				$this->mixActionParameter = $this->intPageNumber - 1;
+				$strPrevious = $this->prxPagination->RenderAsLink($this->strLabelForPrevious, $this->mixActionParameter, ['id'=>$this->ControlId . "_arrow_" . $this->mixActionParameter]);
+				/*
 				$strPrevious = sprintf('<a id="%s" href="%s" %s>%s</a>',
 					$this->ControlId . "_arrow_" . $this->mixActionParameter,
 					QApplication::$RequestUri,
 					$this->prxPagination->RenderAsEvents($this->mixActionParameter, true, $this->ControlId . "_arrow_" . $this->mixActionParameter, false),
-					$this->strLabelForPrevious);
+					$this->strLabelForPrevious);*/
 			}
 
 			$strToReturn = sprintf('<span class="arrow previous">%s</span><span class="break">|</span>', $strPrevious);
@@ -139,11 +141,14 @@
 
 				if ($this->intPageNumber >= $intLeftBunchTrigger) {
 					$this->mixActionParameter = 1;
+					$strToReturn .= $this->prxPagination->RenderAsLink(1, $this->mixActionParameter, ['id'=>$this->ControlId . "_page_" . $this->mixActionParameter]);
+					$strToReturn = sprintf('<span class="page">%s</span>',$strToReturn);
+/*
 					$strToReturn .= sprintf('<span class="page"><a id="%s" href="%s" %s>%s</a></span>',
 						$this->ControlId . "_page_" . $this->mixActionParameter,
 						QApplication::$RequestUri,
 						$this->prxPagination->RenderAsEvents($this->mixActionParameter, true, $this->ControlId . "_page_" . $this->mixActionParameter, false),
-						1);
+						1);*/
 
 					$strToReturn .= '<span class="ellipsis">...</span>';
 				}
@@ -164,11 +169,14 @@
 				$strToReturn = sprintf('<span class="selected">%s</span>', $intIndex);
 			} else {
 				$this->mixActionParameter = $intIndex;
+				$strToReturn = $this->prxPagination->RenderAsLink($intIndex, $this->mixActionParameter, ['id'=>$this->ControlId . "_page_" . $this->mixActionParameter]);
+				$strToReturn = sprintf('<span class="page">%s</span>',$strToReturn);
+				/*
 				$strToReturn = sprintf('<span class="page"><a id="%s" href="%s" %s>%s</a></span>',
 					$this->ControlId . "_page_" . $this->mixActionParameter,
 					QApplication::$RequestUri,
 					$this->prxPagination->RenderAsEvents($this->mixActionParameter, true,
-						$this->ControlId . "_page_" . $this->mixActionParameter, false), $intIndex);
+						$this->ControlId . "_page_" . $this->mixActionParameter, false), $intIndex);*/
 			}
 			return $strToReturn;
 		}
@@ -184,11 +192,13 @@
 				$strNext = $this->strLabelForNext;
 			} else {
 				$this->mixActionParameter = $this->intPageNumber + 1;
+				$strNext = $this->prxPagination->RenderAsLink($this->strLabelForNext, $this->mixActionParameter, ['id'=>$this->ControlId . "_arrow_" . $this->mixActionParameter]);
+/*
 				$strNext = sprintf('<a id="%s" href="%s" %s>%s</a>',
 					$this->ControlId . "_arrow_" . $this->mixActionParameter,
 					QApplication::$RequestUri,
 					$this->prxPagination->RenderAsEvents($this->mixActionParameter, true, $this->ControlId . "_arrow_" . $this->mixActionParameter, false),
-					$this->strLabelForNext);
+					$this->strLabelForNext);*/
 			}
 
 			$strToReturn = sprintf('<span class="arrow next">%s</span>', $strNext);
@@ -203,11 +213,15 @@
 				if ($this->intPageNumber <= $intRightBunchTrigger) {
 
 					$this->mixActionParameter = $this->PageCount;
+					$strToReturn = $this->prxPagination->RenderAsLink($this->PageCount, $this->mixActionParameter, ['id'=>$this->ControlId . "_page_" . $this->mixActionParameter]);
+					$strToReturn = sprintf('<span class="page">%s</span>',$strToReturn);
+
+/*
 					$strToReturn = sprintf('<span class="page"><a id="%s" href="%s" %s>%s</a></span>',
 						$this->ControlId . "_page_" . $this->mixActionParameter,
 						QApplication::$RequestUri,
 						$this->prxPagination->RenderAsEvents($this->mixActionParameter, true, $this->ControlId . "_page_" . $this->mixActionParameter, false),
-						$this->PageCount) . $strToReturn;
+						$this->PageCount) . $strToReturn;*/
 
 					$strToReturn = '<span class="ellipsis">...</span>' . $strToReturn;
 				}

--- a/includes/base_controls/_actions.inc.php
+++ b/includes/base_controls/_actions.inc.php
@@ -82,7 +82,10 @@
 						$strToReturn);
 				} elseif ($objControl instanceof QControlProxy) {
 					if ($objControl->TargetControlId) {
+						// Deprecated.
 						$strOut = sprintf('$j("#%s").on("%s", function(event, ui){%s});', $objControl->TargetControlId, $strEventName, $strToReturn);
+					} else {
+						$strOut = sprintf('$j("#%s").on("%s", "[data-qpxy=\'%s\']", function(event, ui){%s});', $objControl->Form->FormId, $strEventName, $objControl->ControlId, $strToReturn);
 					}
 				} else {
 					$strOut = sprintf('$j("#%s").on("%s", function(event, ui){%s});',
@@ -233,7 +236,7 @@
 			}
 			$objActionParameter = $objControl->ActionParameter;
 			if ($objActionParameter instanceof QJsClosure) {
-				return $objActionParameter->toJsObject() . '.call()';
+				return '(' . $objActionParameter->toJsObject() . ').call(this)';
 			}
 
 			return "'" . addslashes($objActionParameter) . "'";
@@ -352,7 +355,7 @@
 			}
 			$objActionParameter = $objControl->ActionParameter;
 			if ($objActionParameter instanceof QJsClosure) {
-				return $objActionParameter->toJsObject() . '.call()';
+				return '(' . $objActionParameter->toJsObject() . ').call(this)';
 			}
 
 			return "'" . addslashes($objActionParameter) . "'";


### PR DESCRIPTION
Changing QControlProxy to use a jQuery .on function to be more efficient. 
Changing API to be easier to use a proxy and more obvious on how to embed it in a tag.
Fixing examples to reflect changes.