### PR TITLE
bugfix-Minimize

### DIFF
--- a/includes/base_controls/QFormBase.class.php
+++ b/includes/base_controls/QFormBase.class.php
@@ -1688,7 +1688,7 @@
 						$strControlScript = JavaScriptHelper::TerminateScript($strControlScript);
 
 						// Add comments for developer version of output
-						if (!(defined('__MINIMIZE__') && __MINIMIZE)) {
+						if (!QApplication::$Minimize) {
 							// Render a comment
 							$strControlScript = _nl() .  _nl() .
 								sprintf ('/*** EndScript -- Control Type: %s, Control Name: %s, Control Id: %s  ***/',

--- a/includes/base_controls/QTag.class.php
+++ b/includes/base_controls/QTag.class.php
@@ -9,7 +9,7 @@
  * will be printed, and the tag will be correctly terminated.
  *
  * It will normally print the opening and closing tags on their own lines, with the inner html indented once and in-between
- * the two tags. If you define the __MINIMIZE__ constant, it will all be printed on one line with no indents.
+ * the two tags. If you define the __MINIMIZE__ constant or set QApplication::$Minimize variable, it will all be printed on one line with no indents.
  *
  * This control can be used as a drawing aid to draw complex QControls.
  */

--- a/includes/base_controls/_actions.inc.php
+++ b/includes/base_controls/_actions.inc.php
@@ -95,7 +95,7 @@
 				}
 
 				if (isset($strOut)) {
-					if (!(defined('__MINIMIZE__') && __MINIMIZE)) {
+					if (!QApplication::$Minimize) {
 						// Render a comment
 						$strOut = _nl() .  _nl() .
 							sprintf ('/*** Event: %s  Control Type: %s, Control Name: %s, Control Id: %s  ***/', $strEventName, get_class($objControl), $objControl->Name, $objControl->ControlId) .

--- a/includes/base_controls/_utilities.inc.php
+++ b/includes/base_controls/_utilities.inc.php
@@ -87,7 +87,7 @@ function _tp($strString, $blnHtmlEntities = true) {
  * @return string
  */
 function _nl($strText = null) {
-	if (defined ('__MINIMIZE__') && __MINIMIZE__) {
+	if (QApplication::$Minimize) {
 		return $strText;
 	} else {
 		if ($strText === null) return "\n";
@@ -113,7 +113,7 @@ function _nl($strText = null) {
  * @return string
  */
 function _indent($strText, $intCount = 1) {
-	if (!defined('__CODE_GENERATING__') && defined ('__MINIMIZE__') && __MINIMIZE__) {
+	if (!defined('__CODE_GENERATING__') && QApplication::$Minimize) {
 		return $strText;
 	} else {
 		if (defined ('__CODE_GENERATING__')) {

--- a/includes/framework/QApplicationBase.class.php
+++ b/includes/framework/QApplicationBase.class.php
@@ -203,6 +203,13 @@
 		 */
 		public static $LanguageObject;
 
+		/**
+		 * True to force drawing to be minimized.
+		 *
+		 * @var bool
+		 */
+		public static $Minimize = false;
+
 		////////////////////////
 		// Public Overrides
 		////////////////////////
@@ -409,6 +416,10 @@
 				} else {
 					QApplicationBase::$objCacheProvider = new $strCacheProviderClass();
 				}
+			}
+
+			if (defined('__MINIMIZE__') && __MINIMIZE__) {
+				QApplicationBase::$Minimize = true;
 			}
 		}
 

--- a/includes/framework/QHtml.class.php
+++ b/includes/framework/QHtml.class.php
@@ -339,7 +339,7 @@
 		 * @return string
 		 */
 		public static function Comment($strText, $blnRemoveOnMinimize = true) {
-			if ($blnRemoveOnMinimize && defined('__MINIMIZE__') && __MINIMIZE__) {
+			if ($blnRemoveOnMinimize && QApplication::$Minimize) {
 				return '';
 			}
 			return  _nl() . '<!-- ' . $strText . ' -->' . _nl();


### PR DESCRIPTION
Making Minimize into a QApplication global instead of a define so that controls can individually turn it on and off as needed.

The primary thing I am fixing is that in certain situations, like when html objects are styled with inline-block styling, the tabs and returns that are inserted to make the html look good will also add a 4px wide space between objects, causing different drawing when Minimize is on and off. This allows a particular control to always draw minimized so that doesn't happen.