### PR TITLE
bugfix-TypeTableLiterals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,5 @@ before_script:
 
 script: travis/test.php
 
+sudo: false
+

--- a/assets/php/examples/mysql_innodb.sql
+++ b/assets/php/examples/mysql_innodb.sql
@@ -55,6 +55,7 @@ CREATE TABLE project_status_type (
     name VARCHAR(50) NOT NULL,
     description TEXT,
     guidelines TEXT,
+    is_active tinyint(1) NOT NULL,
     CONSTRAINT PK_project_status_type PRIMARY KEY (id),
     UNIQUE KEY IDX_projectstatustype_1(name)
 ) ENGINE=InnoDB;
@@ -169,7 +170,7 @@ ALTER TABLE `person_persontype_assn` ADD CONSTRAINT person_persontype_assn_2 FOR
 #  Type Data                                                                #
 #========================================================================== #
 
-INSERT INTO project_status_type (name, description, guidelines) VALUES ('Open', 'The project is currently active', 'All projects that we are working on should be in this state');
+INSERT INTO project_status_type (name, description, guidelines, is_active) VALUES ('Open', 'The project is currently active', 'All projects that we are working on should be in this state', 1);
 INSERT INTO project_status_type (name, description, guidelines) VALUES ('Cancelled', 'The project has been canned', null);
 INSERT INTO project_status_type (name, description, guidelines) VALUES ('Completed', 'The project has been completed successfully', 'Celebrate successes!');
 

--- a/assets/php/examples/pgsql.sql
+++ b/assets/php/examples/pgsql.sql
@@ -67,6 +67,7 @@ CREATE TABLE project_status_type (
     name VARCHAR(50) NOT NULL,
     description TEXT,
     guidelines TEXT,
+    is_active BOOLEAN,
     CONSTRAINT PK_project_status_type PRIMARY KEY (id),
     UNIQUE (name)
 );
@@ -175,7 +176,7 @@ ALTER TABLE person_persontype_assn ADD CONSTRAINT person_persontype_assn_2 FOREI
 --   Type Data                                                                -- 
 -- ========================================================================== -- 
 
-INSERT INTO project_status_type (name, description, guidelines) VALUES ('Open', 'The project is currently active', 'All projects that we are working on should be in this state');
+INSERT INTO project_status_type (name, description, guidelines, is_active) VALUES ('Open', 'The project is currently active', 'All projects that we are working on should be in this state', 1);
 INSERT INTO project_status_type (name, description, guidelines) VALUES ('Cancelled', 'The project has been canned', null);
 INSERT INTO project_status_type (name, description, guidelines) VALUES ('Completed', 'The project has been completed successfully', 'Celebrate successes!');
 

--- a/assets/php/examples/pgsql.sql
+++ b/assets/php/examples/pgsql.sql
@@ -67,7 +67,7 @@ CREATE TABLE project_status_type (
     name VARCHAR(50) NOT NULL,
     description TEXT,
     guidelines TEXT,
-    is_active BOOLEAN,
+    is_active BOOLEAN NOT NULL,
     CONSTRAINT PK_project_status_type PRIMARY KEY (id),
     UNIQUE (name)
 );
@@ -176,9 +176,9 @@ ALTER TABLE person_persontype_assn ADD CONSTRAINT person_persontype_assn_2 FOREI
 --   Type Data                                                                -- 
 -- ========================================================================== -- 
 
-INSERT INTO project_status_type (name, description, guidelines, is_active) VALUES ('Open', 'The project is currently active', 'All projects that we are working on should be in this state', 1);
-INSERT INTO project_status_type (name, description, guidelines) VALUES ('Cancelled', 'The project has been canned', null);
-INSERT INTO project_status_type (name, description, guidelines) VALUES ('Completed', 'The project has been completed successfully', 'Celebrate successes!');
+INSERT INTO project_status_type (name, description, guidelines, is_active) VALUES ('Open', 'The project is currently active', 'All projects that we are working on should be in this state', TRUE);
+INSERT INTO project_status_type (name, description, guidelines, is_active) VALUES ('Cancelled', 'The project has been canned', null, FALSE);
+INSERT INTO project_status_type (name, description, guidelines, is_active) VALUES ('Completed', 'The project has been completed successfully', 'Celebrate successes!', FALSE);
 
 INSERT INTO person_type (name) VALUES ('Contractor');
 INSERT INTO person_type (name) VALUES ('Manager');

--- a/includes/codegen/QColumn.class.php
+++ b/includes/codegen/QColumn.class.php
@@ -11,7 +11,7 @@
 	 * @property string            $VariableName           Corresponding variable name (in ORM class and elsewhere)
 	 * @property string            $VariableType           Type of data this column is supposed to store (constant from QType class)
 	 * @property string            $VariableTypeAsConstant Variable type expressed as QType casted string (integer column would have this value as: "QType::Integer")
-	 * @property string            $DbType                 Type of databse
+	 * @property string            $DbType                 Type in the database
 	 * @property int               $Length                 If applicable, the length of data to be stored (useful for varchar data types)
 	 * @property mixed             $Default                Default value of the column
 	 * @property boolean           $NotNull                Is this column a "NOT NULL" column?

--- a/includes/codegen/QTypeTable.class.php
+++ b/includes/codegen/QTypeTable.class.php
@@ -77,7 +77,19 @@
 			$this->strName = $strName;
 		}
 
-
+		/**
+		 * Returns the string that will be used to represent the literal value given when codegenning a type table
+		 * @param $mixColValue
+		 * @return string
+		 */
+		public static function Literal($mixColValue) {
+			if (is_null($mixColValue)) return 'null';
+ 			elseif (is_integer($mixColValue)) return $mixColValue;
+			elseif (is_bool($mixColValue)) return ($mixColValue ? 'true' : 'false');
+			elseif (is_float($mixColValue)) return "(float)$mixColValue";
+			elseif (is_object($mixColValue)) return "'" . $mixColValue->_toString() . "'";	// whatever is suitable for the constructor of the object
+			else return "'" . str_replace("'", "\\'", $mixColValue) . "'";
+		}
 
 		////////////////////
 		// Public Overriders

--- a/includes/codegen/templates/db_type/class_gen/_main.tpl.php
+++ b/includes/codegen/templates/db_type/class_gen/_main.tpl.php
@@ -53,23 +53,31 @@
 		public static $ExtraColumnNamesArray = array(
 <?php foreach ($objTypeTable->ExtraFieldNamesArray as $strColName) { ?>
 			'<?= $strColName ?>',
-<?php } ?><?php GO_BACK(2); ?>);
+<?php } ?><?php GO_BACK(2); ?>
+
+		);
 
 		public static $ExtraColumnValuesArray = array(
 <?php foreach ($objTypeTable->ExtraPropertyArray as $intKey=>$arrColumns) { ?>
 			<?= $intKey ?> => array (
-<?php foreach ($arrColumns as $strColName=>$strColValue) { ?>
-						'<?= $strColName ?>' => '<?= str_replace("'", "\\'", $strColValue) ?>',
-<?php } ?><?php GO_BACK(2); ?>),
-<?php } ?><?php GO_BACK(2); ?>);
+<?php 	foreach ($arrColumns as $strColName=>$mixColValue) { ?>
+				'<?= $strColName ?>' => <?= QTypeTable::Literal($mixColValue) ?>,
+<?php 	} ?><?php GO_BACK(2); ?>
+
+			),
+<?php } ?><?php GO_BACK(2); ?>
+
+		);
 
 
 <?php if (count($objTypeTable->ExtraFieldNamesArray)) { ?>
 <?php foreach ($objTypeTable->ExtraFieldNamesArray as $strColName) { ?>
 		public static $<?= $strColName ?>Array = array(
 <?php foreach ($objTypeTable->ExtraPropertyArray as $intKey=>$arrColumns) { ?>
-			<?= $intKey ?> => '<?= str_replace("'", "\\'", $arrColumns[$strColName])  ?>',
-<?php } ?><?php GO_BACK(2); ?>);
+			'<?= $intKey ?>' => <?= QTypeTable::Literal($arrColumns[$strColName]) ?>,
+<?php } ?><?php GO_BACK(2); ?>
+
+		);
 
 <?php } ?>
 <?php } ?>
@@ -100,7 +108,7 @@
 		public static function To<?php echo $strColName  ?>($int<?php echo $objTypeTable->ClassName  ?>Id) {
 			switch ($int<?php echo $objTypeTable->ClassName  ?>Id) {
 <?php foreach ($objTypeTable->ExtraPropertyArray as $intKey=>$arrColumns) { ?>
-				case <?php echo $intKey  ?>: return '<?= str_replace("'", "\\'", $arrColumns[$strColName])  ?>';
+				case <?php echo $intKey  ?>: return <?= QTypeTable::Literal($arrColumns[$strColName]) ?>;
 <?php } ?>
 				default:
 					throw new QCallerException(sprintf('Invalid int<?php echo $objTypeTable->ClassName  ?>Id: %s', $int<?php echo $objTypeTable->ClassName  ?>Id));
@@ -114,7 +122,8 @@
 
 		 * For use in association tables linked to this type.
 		 * @param QQueryBuilder $objBuilder the Query Builder object to update
-		 * @param string $strPrefix optional prefix to add to the SELECT fields
+         * @param string $strPrefix optional prefix to add to the SELECT fields
+         * @param QQSelect|null $objSelect optional select field clause
 		 */
 		public static function GetSelectFields(QQueryBuilder $objBuilder, $strPrefix = null, QQSelect $objSelect = null) {
 			if ($strPrefix) {
@@ -144,11 +153,11 @@
 		 * Takes in an optional strAliasPrefix, used in case another Object::InstantiateDbRow
 		 * is calling this <?= $objTypeTable->ClassName ?>::InstantiateDbRow in order to perform
 		 * early binding on referenced objects.
-		 * @param DatabaseRowBase $objDbRow
-		 * @param string $strAliasPrefix
-		 * @param string $strExpandAsArrayNodes
-		 * @param QBaseClass $arrPreviousItem
-		 * @param string[] $strColumnAliasArray
+		 * @param QDatabaseRowBase $objDbRow
+		 * @param string|null $strAliasPrefix
+		 * @param string|null $strExpandAsArrayNodes
+		 * @param QBaseClass|null $arrPreviousItem
+		 * @param string[]|null $strColumnAliasArray
 		 * @return <?= $objTypeTable->ClassName ?>
 
 		*/
@@ -159,7 +168,7 @@
 			}
 			$strAlias = $strAliasPrefix . 'id';
 			$strAliasName = array_key_exists($strAlias, $strColumnAliasArray) ? $strColumnAliasArray[$strAlias] : $strAlias;
-			$intId = $objDbRow->GetColumn($strAliasName, 'Integer');
+			$intId = $objDbRow->GetColumn($strAliasName, QDatabaseFieldType::Integer);
 			return $intId;
 		}
 	}

--- a/includes/database/QMySqliDatabase.class.php
+++ b/includes/database/QMySqliDatabase.class.php
@@ -567,8 +567,8 @@ if (!defined('MYSQLI_ON_UPDATE_NOW_FLAG')) {
 		/**
 		 * Gets the value of a column from a result row returned by the database
 		 *
-		 * @param string                  $strColumnName Name of te column
-		 * @param null|QDatabaseFieldType $strColumnType Data type
+		 * @param string      	$strColumnName Name of the column
+		 * @param null|string 	$strColumnType A QDatabaseFieldType string
 		 *
 		 * @return mixed
 		 */

--- a/includes/database/QPostgreSqlDatabase.class.php
+++ b/includes/database/QPostgreSqlDatabase.class.php
@@ -580,8 +580,8 @@
 		/**
 		 * Gets the value of a column from a result row returned by the database
 		 *
-		 * @param string                  $strColumnName Name of te column
-		 * @param null|QDatabaseFieldType $strColumnType Data type
+		 * @param string        $strColumnName Name of the column
+		 * @param null|string 	$strColumnType Data type
 		 *
 		 * @return mixed
 		 */

--- a/includes/framework/QQuery.class.php
+++ b/includes/framework/QQuery.class.php
@@ -1160,6 +1160,11 @@
 		// QQSubQuery Factories
 		/////////////////////////
 
+		/**
+		 * @param string $strSql
+		 * @param null|QQNode[] $objParentQueryNodes	Array of nodes to specify replacement value in the sql.
+		 * @return QQSubQuerySqlNode
+		 */
 		static public function SubSql($strSql, $objParentQueryNodes = null) {
 			$objParentQueryNodeArray = func_get_args();
 			return new QQSubQuerySqlNode($strSql, $objParentQueryNodeArray);

--- a/includes/tests/qcubed-unit/QTypeTests.php
+++ b/includes/tests/qcubed-unit/QTypeTests.php
@@ -113,5 +113,17 @@ class QTypeTests extends QUnitTestCaseBase {
 		$a = Project::QueryArray($cond);
 		$this->assertEqual(count($a), 3, "Between 2 string types works");
 	}
+
+	// Testing creation of type tables
+
+	public function testTypeTableTypes() {
+		$val = ProjectStatusType::$GuidelinesArray[2];
+		$this->assertNull($val, 'Generated a null value');
+
+		$val = ProjectStatusType::$IsActiveArray[1];
+		$this->assertEqual($val, true, 'Open project is active');
+		$this->assertEqual(is_bool($val), true, 'Type of variable is boolean.');
+
+	}
 }
 ?>


### PR DESCRIPTION
Fixing problem for type tables where the resulting constant literals were always strings. They are now the correct PHP type of value, depending not he database type.