### PR TITLE
bugfix-DecimalType

### DIFF
--- a/includes/database/QMySqli5Database.class.php
+++ b/includes/database/QMySqli5Database.class.php
@@ -130,7 +130,7 @@
 		protected function SetFieldType($intMySqlFieldType) {
 			switch ($intMySqlFieldType) {
 				case MYSQLI_TYPE_NEWDECIMAL:
-					$this->strType = QDatabaseFieldType::Float;
+					$this->strType = QDatabaseFieldType::VarChar;
 					break;
 
 				case MYSQLI_TYPE_BIT:

--- a/includes/database/QMySqliDatabase.class.php
+++ b/includes/database/QMySqliDatabase.class.php
@@ -709,6 +709,13 @@ if (!defined('MYSQLI_ON_UPDATE_NOW_FLAG')) {
 					break;
 				case MYSQLI_TYPE_NEWDECIMAL:
 				case MYSQLI_TYPE_DECIMAL:
+					// NOTE: PHP's best response to fixed point exact precision numbers is to use the bcmath library.
+					// bcmath requires string inputs. If you try to do math directly on these, PHP will convert to float,
+					// so for those who care, they will need to be careful. For those who do not care, then PHP will do
+					// the conversion anyway.
+					$this->strType = QDatabaseFieldType::VarChar;
+					break;
+
 				case MYSQLI_TYPE_FLOAT:
 					$this->strType = QDatabaseFieldType::Float;
 					break;

--- a/includes/database/QPostgreSqlDatabase.class.php
+++ b/includes/database/QPostgreSqlDatabase.class.php
@@ -759,7 +759,14 @@
 					throw new QPostgreSqlDatabaseException('Unsupported Field Type: money.  Use numeric or decimal instead.', 0,null);
 					break;
 				case 'decimal':
-				case 'numeric':					
+				case 'numeric':
+					// NOTE: PHP's best response to fixed point exact precision numbers is to use the bcmath library.
+					// bcmath requires string inputs. If you try to do math directly on these, PHP will convert to float,
+					// so for those who care, they will need to be careful. For those who do not care, then PHP will do
+					// the conversion automatically.
+					$this->strType = QDatabaseFieldType::VarChar;
+					break;
+
 				case 'real':
 					$this->strType = QDatabaseFieldType::Float;
 					break;					

--- a/includes/database/QPostgreSqlPdoDatabase.class.php
+++ b/includes/database/QPostgreSqlPdoDatabase.class.php
@@ -606,7 +606,14 @@ class QPostgreSqlPdoDatabaseField extends QDatabaseFieldBase {
 								break;
 						case 'decimal':
 						case 'numeric':
-						case 'real':
+							// NOTE: PHP's best response to fixed point exact precision numbers is to use the bcmath library.
+							// bcmath requires string inputs. If you try to do math directly on these, PHP will convert to float,
+							// so for those who care, they will need to be careful. For those who do not care, then PHP will do
+							// the conversion automatically.
+							$this->strType = QDatabaseFieldType::VarChar;
+							break;
+
+					case 'real':
 								$this->strType = QDatabaseFieldType::Float;
 								break;
 						case 'bit':

--- a/includes/database/QSqLite3PdoDatabase.class.php
+++ b/includes/database/QSqLite3PdoDatabase.class.php
@@ -482,10 +482,19 @@ class QSqLite3PdoDatabaseField extends QDatabaseFieldBase {
 			case 'MEDIUMINT':
 				$this->strType = QDatabaseFieldType::Integer;
 				break;
+			
 			case 'FLOAT':
-			case 'DECIMAL':
 				$this->strType = QDatabaseFieldType::Float;
 				break;
+
+			case 'DECIMAL':
+				// NOTE: PHP's best response to fixed point exact precision numbers is to use the bcmath library.
+				// bcmath requires string inputs. If you try to do math directly on these, PHP will convert to float,
+				// so for those who care, they will need to be careful. For those who do not care, then PHP will do
+				// the conversion anyway.
+				$this->strType = QDatabaseFieldType::VarChar;
+				break;
+
 			case 'DOUBLE':
 				// NOTE: PHP does not offer full support of double-precision floats.
 				// Value will be set as a VarChar which will guarantee that the precision will be maintained.


### PR DESCRIPTION
Making Decimal values be PHP strings instead of floats. The whole purpose for decimals is precise tracking of fractions, and converting to floats completely looses that benefit. It also prevents using the bcmath library to do precision math with the Decimal number. If the developer wants a float, they should  just specify a float. Anyways, if the developer still wants a float, PHP will do the conversion automatically when it is used in a math operation.