### PR TITLE
Fixed abnormal behavior on Paginator's boundary condition with intLeftBunchTrigger

### DIFF
--- a/includes/base_controls/QPaginatorBase.class.php
+++ b/includes/base_controls/QPaginatorBase.class.php
@@ -318,7 +318,7 @@
 			$intLeftBunchTrigger = 4 + $intLeftOfBunchCount;
 			$intRightBunchTrigger = $intMaximumStartOfBunch + round(($this->intIndexCount - 8.0) / 2.0);
 
-			if ($this->intPageNumber < $intLeftBunchTrigger) {
+			if ($this->intPageNumber <= $intLeftBunchTrigger) {
 				$intPageStart = 1;
 			} else {
 				$intPageStart = min($intMaximumStartOfBunch, $this->intPageNumber - $intLeftOfBunchCount);


### PR DESCRIPTION
The paginator was showing the following with IndexCount as 10 and page number 6 (where 6 was the last page).
<img width="418" alt="screenshot 2015-09-03 10 58 36" src="https://cloud.githubusercontent.com/assets/2824682/9651190/d164f368-522a-11e5-8d81-be7c593e2e64.png">

This pull request fixes the boundary condition failure.