### PR TITLE
Changing single-column index errors to warnings 

### DIFF
--- a/includes/codegen/QDatabaseCodeGen.class.php
+++ b/includes/codegen/QDatabaseCodeGen.class.php
@@ -916,10 +916,10 @@
 							$objTable->IndexArray = $objIndexArray;
 
 							if ($objIndex->Unique)
-								$this->strErrors .= sprintf("Notice: It is recommended that you add a single-column UNIQUE index on \"%s.%s\" for the Foreign Key %s\r\n",
+								$this->strWarnings .= sprintf("Notice: It is recommended that you add a single-column UNIQUE index on \"%s.%s\" for the Foreign Key %s\r\n",
 									$strTableName, $strColumnName, $objForeignKey->KeyName);
 							else
-								$this->strErrors .= sprintf("Notice: It is recommended that you add a single-column index on \"%s.%s\" for the Foreign Key %s\r\n",
+								$this->strWarnings .= sprintf("Notice: It is recommended that you add a single-column index on \"%s.%s\" for the Foreign Key %s\r\n",
 									$strTableName, $strColumnName, $objForeignKey->KeyName);
 						}
 

--- a/includes/codegen/QDatabaseCodeGen.class.php
+++ b/includes/codegen/QDatabaseCodeGen.class.php
@@ -519,10 +519,10 @@
 
 
 						if (!$objReferencedColumn->PrimaryKey) {
-							$this->strWarnings .= sprintf("Warning: Invalid Relationship created in %s class (for foreign key \"%s\") -- column \"%s\" is not the single-column primary key for the referenced \"%s\" table\r\n",
+							$this->strErrors .= sprintf("Warning: Invalid Relationship created in %s class (for foreign key \"%s\") -- column \"%s\" is not the single-column primary key for the referenced \"%s\" table\r\n",
 								$objReferencedTable->ClassName, $objReference->KeyName, $objReferencedColumn->Name, $objReferencedTable->Name);
 						} else if (count($objReferencedTable->PrimaryKeyColumnArray) != 1) {
-							$this->strWarnings .= sprintf("Warning: Invalid Relationship created in %s class (for foreign key \"%s\") -- column \"%s\" is not the single-column primary key for the referenced \"%s\" table\r\n",
+							$this->strErrors .= sprintf("Warning: Invalid Relationship created in %s class (for foreign key \"%s\") -- column \"%s\" is not the single-column primary key for the referenced \"%s\" table\r\n",
 								$objReferencedTable->ClassName, $objReference->KeyName, $objReferencedColumn->Name, $objReferencedTable->Name);
 						}
 					}


### PR DESCRIPTION
Changing single-column index errors to warnings (because everything would still work). In my application, there are tables where I would not make a single-column search ever. A double-coulmn index serves the purpose and there are no performance drops anyway. 

Therefore, such a case should not stop the aggregation codegen templates from being run. This commit ensures the same.