### PR TITLE
bugfix-RedirectDefault

### DIFF
--- a/includes/base_controls/QHtmlAttributeManagerBase.class.php
+++ b/includes/base_controls/QHtmlAttributeManagerBase.class.php
@@ -8,7 +8,7 @@
  */
 
 /**
- * A base blass for objects that manage html attributes. Uses array functions and defines a couple of arrays to manage
+ * A base class for objects that manage html attributes. Uses array functions and defines a couple of arrays to manage
  * the attributes. Values will be html escaped when printed.
  *
  * Includes:

--- a/includes/framework/QApplicationBase.class.php
+++ b/includes/framework/QApplicationBase.class.php
@@ -576,11 +576,13 @@
 		 * This will redirect the user to a new web location.  This can be a relative or absolute web path, or it
 		 * can be an entire URL.
 		 *
+		 * TODO: break this into two routines, since the resulting UI behavior is really different. Redirect and LoadPage??
+		 *
 		 * @param string $strLocation target patch
 		 * @param bool $blnAbortCurrentScript Whether to abort the current script, or finish it out so data gets saved.
 		 * @return void
 		 */
-		public static function Redirect($strLocation, $blnAbortCurrentScript = false) {
+		public static function Redirect($strLocation, $blnAbortCurrentScript = true) {
 
 			if (!$blnAbortCurrentScript) {
 				// Use the javascript command mechanism


### PR DESCRIPTION
Changing the default to be the V2 way of redirecting. Defaulting to sending a javascript causes a number of other problems, including unexpected saves and screen flashes. Having a javascript way of doing is still important, but it is the exception more than the rule.