### PR TITLE
feature-QQueryRefactor

### DIFF
--- a/includes/base_controls/QControlBase.class.php
+++ b/includes/base_controls/QControlBase.class.php
@@ -2204,7 +2204,7 @@
 				// CODEGEN
 				case "LinkedNode":
 					try {
-						$this->objLinkedNode = QType::Cast($mixValue, 'QQBaseNode');
+						$this->objLinkedNode = QType::Cast($mixValue, 'QQNode');
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();

--- a/includes/base_controls/QSimpleTableColumn.class.php
+++ b/includes/base_controls/QSimpleTableColumn.class.php
@@ -524,7 +524,7 @@
 		 * @param string $strName name of the column
 		 * @param string $strProperty the property name to use when accessing the DataSource row object. Can be null, in which case object will
 		 *  have the ->__toString() function called on it.
-		 * @param QQBaseNode $objBaseNode if not null the OrderBy and ReverseOrderBy clauses will be created using the property path and the given database node
+		 * @param QQNode $objBaseNode if not null the OrderBy and ReverseOrderBy clauses will be created using the property path and the given database node
 		 */
 		public function __construct($strName, $strProperty, $objBaseNode = null) {
 			parent::__construct($strName);

--- a/includes/codegen/templates/db_orm/class_gen/class_info.tpl.php
+++ b/includes/codegen/templates/db_orm/class_gen/class_info.tpl.php
@@ -1,15 +1,10 @@
-<?php
-	/**
-	 * Created by vaibhav on 6/26/12 (9:46 AM).
-	 */
-?>
 
 		///////////////////////////////
 		// METHODS TO EXTRACT INFO ABOUT THE CLASS
 		///////////////////////////////
 
 		/**
-		 * Static method to retrieve the Database object that owns this class.
+		 * Static method to retrieve the Table name that owns this class.
 		 * @return string Name of the table from which this class has been created.
 		 */
 		public static function GetTableName() {
@@ -17,8 +12,8 @@
 		}
 
 		/**
-		 * Static method to retrieve the Table name from which this class has been created.
-		 * @return string Name of the table from which this class has been created.
+		 * Static method to retrieve the Database name from which this class has been created.
+		 * @return string Name of the database from which this class has been created.
 		 */
 		public static function GetDatabaseName() {
 			return QApplication::$Database[<?= $objTable->ClassName; ?>::GetDatabaseIndex()]->Database;
@@ -33,4 +28,12 @@
 		 */
 		public static function GetDatabaseIndex() {
 			return <?= $objCodeGen->DatabaseIndex; ?>;
+		}
+
+		/**
+		 * Return the base node corresponding to this table.
+		 * @return int position or index of the database in the config file.
+		 */
+		public static function BaseNode() {
+			return QQN::<?= $objTable->ClassName; ?>();
 		}

--- a/includes/codegen/templates/db_orm/class_gen/instantiation_methods.tpl.php
+++ b/includes/codegen/templates/db_orm/class_gen/instantiation_methods.tpl.php
@@ -21,7 +21,7 @@
 		 * early binding on referenced objects.
 		 * @param DatabaseRowBase $objDbRow
 		 * @param string $strAliasPrefix
-		 * @param QQBaseNode $objExpandAsArrayNode
+		 * @param QQNode $objExpandAsArrayNode
 		 * @param QBaseClass $arrPreviousItem
 		 * @param string[] $strColumnAliasArray
 		 * @param boolean $blnCheckDuplicate Used by ExpandArray to indicate we should not create a new object if this is a duplicate of a previoius object
@@ -213,7 +213,7 @@
 		/**
 		 * Instantiate an array of <?= $objTable->ClassNamePlural ?> from a Database Result
 		 * @param DatabaseResultBase $objDbResult
-		 * @param QQBaseNode $objExpandAsArrayNode
+		 * @param QQNode $objExpandAsArrayNode
 		 * @param string[] $strColumnAliasArray
 		 * @return <?= $objTable->ClassName ?>[]
 		 */

--- a/includes/codegen/templates/db_orm/class_gen/qcubed_query_classes.tpl.php
+++ b/includes/codegen/templates/db_orm/class_gen/qcubed_query_classes.tpl.php
@@ -6,7 +6,7 @@
     /**
      * @uses QQAssociationNode
      *
-     * @property-read QQNode $<?= $objReference->OppositePropertyName ?>
+     * @property-read QQColumnNode $<?= $objReference->OppositePropertyName ?>
 
      * @property-read QQNode<?= $objReference->VariableType ?> $<?= $objReference->VariableType ?>
 
@@ -25,7 +25,7 @@
 		public function __get($strName) {
 			switch ($strName) {
 				case '<?= $objReference->OppositePropertyName ?>':
-					return new QQNode('<?= $objReference->OppositeColumn ?>', '<?= $objReference->OppositePropertyName ?>', '<?= $objReference->OppositeDbType ?>', $this);
+					return new QQColumnNode('<?= $objReference->OppositeColumn ?>', '<?= $objReference->OppositePropertyName ?>', '<?= $objReference->OppositeDbType ?>', $this);
 				case '<?= $objReference->VariableType ?>':
 					return new QQNode<?= $objReference->VariableType ?>('<?= $objReference->OppositeColumn ?>', '<?= $objReference->OppositePropertyName ?>', '<?= $objReference->OppositeDbType ?>', $this);
 				case '_ChildTableNode':
@@ -43,10 +43,10 @@
 
 <?php } ?>
     /**
-     * @uses QQNode
+     * @uses QQTableNode
      *
 <?php foreach ($objTable->ColumnArray as $objColumn) { ?>
-     * @property-read QQNode $<?= $objColumn->PropertyName ?>
+     * @property-read QQColumnNode $<?= $objColumn->PropertyName ?>
 
 <?php if (($objColumn->Reference) && (!$objColumn->Reference->IsType)) { ?>
      * @property-read QQNode<?= $objColumn->Reference->VariableType; ?> $<?= $objColumn->Reference->PropertyName ?>
@@ -67,15 +67,37 @@
 
      * @property-read QQNode<?php if (($objPkColumn->Reference) && (!$objPkColumn->Reference->IsType)) print $objPkColumn->Reference->VariableType; ?> $_PrimaryKeyNode
      **/
-	class QQNode<?= $objTable->ClassName ?> extends QQNode {
+	class QQNode<?= $objTable->ClassName ?> extends QQTableNode {
 		protected $strTableName = '<?= $objTable->Name ?>';
 		protected $strPrimaryKey = '<?= $objTable->PrimaryKeyColumnArray[0]->Name ?>';
 		protected $strClassName = '<?= $objTable->ClassName ?>';
+
+		public function Fields() {
+			return [
+<?php foreach ($objTable->ColumnArray as $objColumn) { ?>
+				"<?= $objColumn->Name ?>",
+<?php } ?>
+			];
+		}
+
+		public function PrimaryKeyFields() {
+			return [
+<?php foreach ($objTable->PrimaryKeyColumnArray as $objColumn) { ?>
+				"<?= $objColumn->Name ?>",
+<?php } ?>
+			];
+		}
+
+		protected function database() {
+			return QApplication::$Database[<?= $objCodeGen->DatabaseIndex; ?>];
+		}
+
+
 		public function __get($strName) {
 			switch ($strName) {
 <?php foreach ($objTable->ColumnArray as $objColumn) { ?>
 				case '<?= $objColumn->PropertyName ?>':
-					return new QQNode('<?= $objColumn->Name ?>', '<?= $objColumn->PropertyName ?>', '<?= $objColumn->DbType ?>', $this);
+					return new QQColumnNode('<?= $objColumn->Name ?>', '<?= $objColumn->PropertyName ?>', '<?= $objColumn->DbType ?>', $this);
 <?php if ($objColumn->Reference) { ?>
 				case '<?= $objColumn->Reference->PropertyName ?>':
 					return new QQNode<?= $objColumn->Reference->VariableType; ?>('<?= $objColumn->Name ?>', '<?= $objColumn->Reference->PropertyName ?>', '<?= $objColumn->DbType ?>', $this);
@@ -90,7 +112,11 @@
 <?php } ?><?php $objPkColumn = $objTable->PrimaryKeyColumnArray[0]; ?>
 
 				case '_PrimaryKeyNode':
-					return new QQNode<?php if (($objPkColumn->Reference) && (!$objPkColumn->Reference->IsType)) print $objPkColumn->Reference->VariableType; ?>('<?= $objPkColumn->Name ?>', '<?= $objPkColumn->PropertyName ?>', '<?= $objPkColumn->DbType ?>', $this);
+<?php if (($objPkColumn->Reference) && (!$objPkColumn->Reference->IsType)) {?>
+					return new QQNode<?= $objPkColumn->Reference->VariableType; ?>('<?= $objPkColumn->Name ?>', '<?= $objPkColumn->PropertyName ?>', '<?= $objPkColumn->DbType ?>', $this);
+<?php } else { ?>
+					return new QQColumnNode('<?= $objPkColumn->Name ?>', '<?= $objPkColumn->PropertyName ?>', '<?= $objPkColumn->DbType ?>', $this);
+<?php } ?>
 				default:
 					try {
 						return parent::__get($strName);
@@ -104,7 +130,7 @@
 
     /**
 <?php foreach ($objTable->ColumnArray as $objColumn) { ?>
-     * @property-read QQNode $<?= $objColumn->PropertyName ?>
+     * @property-read QQColumnNode $<?= $objColumn->PropertyName ?>
 
 <?php if (($objColumn->Reference) && (!$objColumn->Reference->IsType)) { ?>
      * @property-read QQNode<?= $objColumn->Reference->VariableType; ?> $<?= $objColumn->Reference->PropertyName ?>
@@ -129,11 +155,28 @@
 		protected $strTableName = '<?= $objTable->Name ?>';
 		protected $strPrimaryKey = '<?= $objTable->PrimaryKeyColumnArray[0]->Name ?>';
 		protected $strClassName = '<?= $objTable->ClassName ?>';
+
+		public function Fields() {
+			return [
+<?php foreach ($objTable->ColumnArray as $objColumn) { ?>
+				"<?= $objColumn->Name ?>",
+<?php } ?>
+			];
+		}
+
+		public function PrimaryKeyFields() {
+			return [
+<?php foreach ($objTable->PrimaryKeyColumnArray as $objColumn) { ?>
+				"<?= $objColumn->Name ?>",
+<?php } ?>
+			];
+		}
+
 		public function __get($strName) {
 			switch ($strName) {
 <?php foreach ($objTable->ColumnArray as $objColumn) { ?>
 				case '<?= $objColumn->PropertyName ?>':
-					return new QQNode('<?= $objColumn->Name ?>', '<?= $objColumn->PropertyName ?>', '<?= $objColumn->DbType ?>', $this);
+					return new QQColumnNode('<?= $objColumn->Name ?>', '<?= $objColumn->PropertyName ?>', '<?= $objColumn->DbType ?>', $this);
 <?php if (($objColumn->Reference) && (!$objColumn->Reference->IsType)) { ?>
 				case '<?= $objColumn->Reference->PropertyName ?>':
 					return new QQNode<?= $objColumn->Reference->VariableType; ?>('<?= $objColumn->Name ?>', '<?= $objColumn->Reference->PropertyName ?>', '<?= $objColumn->DbType ?>', $this);
@@ -148,7 +191,11 @@
 <?php } ?><?php $objPkColumn = $objTable->PrimaryKeyColumnArray[0]; ?>
 
 				case '_PrimaryKeyNode':
-					return new QQNode<?php if (($objPkColumn->Reference) && (!$objPkColumn->Reference->IsType)) print $objPkColumn->Reference->VariableType; ?>('<?= $objPkColumn->Name ?>', '<?= $objPkColumn->PropertyName ?>', '<?= $objPkColumn->DbType ?>', $this);
+<?php if (($objPkColumn->Reference) && (!$objPkColumn->Reference->IsType)) {?>
+					return new QQNode<?= $objPkColumn->Reference->VariableType; ?>('<?= $objPkColumn->Name ?>', '<?= $objPkColumn->PropertyName ?>', '<?= $objPkColumn->DbType ?>', $this);
+<?php } else { ?>
+					return new QQColumnNode('<?= $objPkColumn->Name ?>', '<?= $objPkColumn->PropertyName ?>', '<?= $objPkColumn->DbType ?>', $this);
+<?php } ?>
 				default:
 					try {
 						return parent::__get($strName);

--- a/includes/codegen/templates/db_orm/class_gen/qcubed_query_methods.tpl.php
+++ b/includes/codegen/templates/db_orm/class_gen/qcubed_query_methods.tpl.php
@@ -6,31 +6,3 @@
 	// public static function QueryCount(QQCondition $objConditions, $objOptionalClauses = null, $mixParameterArray = null) {
 	// public static function QueryArrayCached(QQCondition $objConditions, $objOptionalClauses = null, $mixParameterArray = null, $blnForceUpdate = false) {
 
-		/**
-		 * Updates a QQueryBuilder with the SELECT fields for this <?= $objTable->ClassName ?>
-
-		 * @param QQueryBuilder $objBuilder the Query Builder object to update
-		 * @param string $strPrefix optional prefix to add to the SELECT fields
-		 */
-		public static function GetSelectFields(QQueryBuilder $objBuilder, $strPrefix = null, QQSelect $objSelect = null) {
-			if ($strPrefix) {
-				$strTableName = $strPrefix;
-				$strAliasPrefix = $strPrefix . '__';
-			} else {
-				$strTableName = '<?= $objTable->Name; ?>';
-				$strAliasPrefix = '';
-			}
-
-			if ($objSelect) {
-				if (!$objSelect->SkipPrimaryKey()) {
-<?php foreach ($objTable->PrimaryKeyColumnArray as $objColumn) { ?>
-					$objBuilder->AddSelectItem($strTableName, '<?= $objColumn->Name ?>', $strAliasPrefix . '<?= $objColumn->Name ?>');
-<?php } ?>
-				}
-                $objSelect->AddSelectItems($objBuilder, $strTableName, $strAliasPrefix);
-			} else {
-<?php foreach ($objTable->ColumnArray as $objColumn) { ?>
-				$objBuilder->AddSelectItem($strTableName, '<?= $objColumn->Name ?>', $strAliasPrefix . '<?= $objColumn->Name ?>');
-<?php } ?>
-			}
-		}

--- a/includes/codegen/templates/db_type/class_gen/_main.tpl.php
+++ b/includes/codegen/templates/db_type/class_gen/_main.tpl.php
@@ -117,31 +117,6 @@
 
 <?php } ?>
 
-		/**
-		 * Updates a QQueryBuilder with the SELECT fields for this <?= $objTypeTable->ClassName ?>
-
-		 * For use in association tables linked to this type.
-		 * @param QQueryBuilder $objBuilder the Query Builder object to update
-         * @param string $strPrefix optional prefix to add to the SELECT fields
-         * @param QQSelect|null $objSelect optional select field clause
-		 */
-		public static function GetSelectFields(QQueryBuilder $objBuilder, $strPrefix = null, QQSelect $objSelect = null) {
-			if ($strPrefix) {
-				$strTableName = $strPrefix;
-				$strAliasPrefix = $strPrefix . '__';
-			} else {
-				$strTableName = '<?= $objTypeTable->Name; ?>';
-				$strAliasPrefix = '';
-			}
-
-            if ($objSelect) {
-			    $objBuilder->AddSelectItem($strTableName, 'id', $strAliasPrefix . 'id');
-                $objSelect->AddSelectItems($objBuilder, $strTableName, $strAliasPrefix);
-            } else {
-			    $objBuilder->AddSelectItem($strTableName, 'id', $strAliasPrefix . 'id');
-			    $objBuilder->AddSelectItem($strTableName, 'name', $strAliasPrefix . 'name');
-            }
-		}
 
 		///////////////////////////////
 		// INSTANTIATION-RELATED METHODS
@@ -181,17 +156,26 @@
      * @property-read QQNode $Name
      * @property-read QQNode $_PrimaryKeyNode
      **/
-	class QQNode<?= $objTypeTable->ClassName ?> extends QQNode {
+	class QQNode<?= $objTypeTable->ClassName ?> extends QQTableNode {
 		protected $strTableName = '<?= $objTypeTable->Name ?>';
 		protected $strPrimaryKey = 'id';
 		protected $strClassName = '<?= $objTypeTable->ClassName ?>';
 		protected $blnIsType = true;
+
+		public function Fields() {
+			return ["id", "name"];
+		}
+
+		public function PrimaryKeyFields() {
+			return ["id"];
+		}
+
 		public function __get($strName) {
 			switch ($strName) {
 			 	case 'Id':
-					return new QQNode('id', 'Id', 'Integer', $this);
+					return new QQColumnNode('id', 'Id', 'Integer', $this);
 				case '_PrimaryKeyNode':
-					return new QQNode('id', 'Id', 'Integer', $this);
+					return new QQColumnNode('id', 'Id', 'Integer', $this);
 				default:
 					try {
 						return parent::__get($strName);

--- a/includes/framework/QQuery.class.php
+++ b/includes/framework/QQuery.class.php
@@ -2349,6 +2349,8 @@
 				$this->strEscapeIdentifierBegin, $this->GetTableAlias($strJoinTableAlias), $this->strEscapeIdentifierEnd
 			);
 
+			$strJoinIndex = $strJoinItem;
+
 			try {
 				if (($strConditionClause = $objJoinCondition->GetWhereClause($this, true)))
 					$strJoinItem .= ' AND ' . $strConditionClause;
@@ -2357,7 +2359,7 @@
 				throw $objExc;
 			}
 
-			$this->strJoinArray[$strJoinItem] = $strJoinItem;
+			$this->strJoinArray[$strJoinIndex] = $strJoinItem;
 		}
 
 		/**

--- a/includes/tests/qcubed-unit/BasicOrmTests.php
+++ b/includes/tests/qcubed-unit/BasicOrmTests.php
@@ -330,5 +330,15 @@ class BasicOrmTests extends QUnitTestCaseBase {
 		$this->assertNull($objLogin, "New record should not be associated with null PK.");
 	}
 
+	public function testOrderByReverseReference() {
+		// orders by the private key of the reverse reference node.
+		$objPerson = Person::QuerySingle(
+			QQ::IsNotNull(QQN::Person()->ProjectAsManager->Id),
+			[QQ::OrderBy(QQN::Person()->ProjectAsManager)]
+		);
+		$this->assertEqual($objPerson->Id, 7, "Manager of first project found.");
+
+	}
+
 }
 ?>

--- a/includes/tests/qcubed-unit/ExpandAsArrayTests.php
+++ b/includes/tests/qcubed-unit/ExpandAsArrayTests.php
@@ -348,6 +348,36 @@ class ExpandAsArrayTests extends QUnitTestCaseBase {
 
 	}
 
+	public function testConditionalExpansionReverse() {
+		// Get all people, and projects they are managing if the projects are open.
+		$a = Person::QueryArray(
+			QQ::All(),
+			[
+				QQ::ExpandAsArray(QQN::Person()->ProjectAsManager, QQ::Equal(QQN::Person()->ProjectAsManager->ProjectStatusTypeId, ProjectStatusType::Open)),
+				QQ::OrderBy(QQN::Person()->Id)
+			]
+		);
+
+		$this->assertEqual($a[0]->_ProjectAsManagerArray[0]->Id, 3);
+	}
+
+	public function testConditionalExpansionAssociation() {
+		// Conditional expansion on association nodes really can only work with the PK of the join.
+
+		// Get all projects, and also expand on related projects if the id is 1
+		$a = Project::QueryArray(
+			QQ::All(),
+			[
+				QQ::ExpandAsArray(QQN::Project()->ParentProjectAsRelated, QQ::Equal(QQN::Project()->ParentProjectAsRelated->ProjectId, 1)),
+				QQ::ExpandAsArray(QQN::Project()->ProjectAsRelated, QQ::Equal(QQN::Project()->ProjectAsRelated->Project->Id, 1)),
+				QQ::OrderBy(QQN::Project()->Id)
+			]
+		);
+
+		$this->assertEqual($a[2]->_ParentProjectAsRelatedArray[0]->Id, 1);
+	}
+
+
 
 	public function testDataGridHtml() {
 		$objMilestone = Milestone::QuerySingle(

--- a/includes/watchers/QWatcherBase.class.php
+++ b/includes/watchers/QWatcherBase.class.php
@@ -43,9 +43,9 @@
 		/**
 		 * Call from control to watch a node. Watches all tables associated with the node.
 		 * 
-		 * @param QQNode $objNode
+		 * @param QQTableNode $objNode
 		 */
-		public function Watch(QQNode $objNode) {
+		public function Watch(QQTableNode $objNode) {
 			$strClassName = $objNode->_ClassName;
 
 			if (!$strClassName::$blnWatchChanges) {


### PR DESCRIPTION
Refactor of the QQuery code. Does the following:
- Documenting functions
- Remove most warnings
- Removes the QQBaseNode. All nodes derive from QQNode.
- Creates the concept of a QColumnNode and QTableNode to differentiate leaf and stem nodes. This allows PHPs own type checking system to do some type checking.
- Moves Fields to the nodes to make them more available to the join code. Slight speed improvement as a result, but it at least avoids the need to do a function call on a variable named class.
- GetColumnAlias is not overloaded to also do the join of nodes. There is now a Join function. They are separate functions for better understanding, and so that GetColumnAlias will only apply to column nodes and not table nodes.
- Adds the ability to sort on a reverse reference node.
- Fixes a bug that prevented joining an association table on itself with a conditional join. Added a test case to catch that.
- Conditional ExpandAsArray joins.

This will require a code regeneration, but otherwise, should not impact existing code. Their may be situations where someone is using a table node in a comparison. The old code would allow this, and internally use the PK of the table instead. This is no longer allowed, you must explicitly specify the primary key of the table from now on, or some other column node. Table nodes can still be used in order by and group by clauses, and it will default to the pk in those situations.

Yet To Do:
 - Did not remove the HTML generating code. For another day, or someone else to do.