### PR TITLE
bugfix-PaginatorVariable

### DIFF
--- a/includes/base_controls/QPaginatorBase.class.php
+++ b/includes/base_controls/QPaginatorBase.class.php
@@ -35,6 +35,9 @@
 		protected $objPaginatedControl;
 		/** @var string Default Wait Icon to be used */
 		protected $objWaitIcon = 'default';
+		/** @var int Number of index items in the paginator to display */
+		protected $intIndexCount = 10;
+
 
 		/** @var null|\QControlProxy  */
 		protected $prxPagination = null;


### PR DESCRIPTION
This variable is defined in the subclass only, but used in the superclass. This fix adds the definition to the superclass too.