### PR TITLE
bugfix-EmptyDataRepeater

### DIFF
--- a/includes/base_controls/QDataRepeater.class.php
+++ b/includes/base_controls/QDataRepeater.class.php
@@ -160,13 +160,13 @@ class QDataRepeater extends QPaginatedControl {
 				$this->intCurrentItemIndex++;
 			}
 
-			$strToReturn = $this->RenderTag($this->strTagName,
-				null,
-				null,
-				$strEvalledItems);
-
 			$_CONTROL = $objCurrentControl;
 		}
+
+		$strToReturn = $this->RenderTag($this->strTagName,
+			null,
+			null,
+			$strEvalledItems);
 
 		$this->objDataSource = null;
 		return $strToReturn;


### PR DESCRIPTION
Fixing problem with data repeater. If the data binder returns no data, the data repeater is removed from the dom. If the data binder then returns data later, the data grid will be placed back in the dom, but at the end of the form since there is no remnant of the data repeater to know where to put it.