### PR TITLE
bugfix-ExecuteMissingFunction

### DIFF
--- a/assets/js/qcubed.js
+++ b/assets/js/qcubed.js
@@ -559,7 +559,10 @@ qcubed = {
 
                     // apply the function on each jQuery object found, using the found jQuery object as the context.
                     objs.each (function () {
-                         $j(this)[command.func].apply($j(this), params);
+                        var $item = $j(this);
+                        if ($item[command.func]) {
+                            $item[command.func].apply($j(this), params);
+                        }
                     });
                 }
                 else if (this.func) {


### PR DESCRIPTION
Fixing problem that occurs when trying to execute a javascript function that does not exist. Doing so will bring down the rest of the javascript on the page. We check to see if the javascript function exists before executing.