### PR TITLE
bugfix-ForceBlockElement

### DIFF
--- a/includes/base_controls/QControlBase.class.php
+++ b/includes/base_controls/QControlBase.class.php
@@ -1266,7 +1266,7 @@
 		 *   Your html-code which should be printed out
 		 * @param boolean $blnDisplayOutput
 		 *   should it be printed, or just be returned?
-\		 * @param string  $strHasDataRel
+		 * @param string  $strHasDataRel
 		 *   Will contain an additional attribute for ajax processing to tie related html objects together if there is no
 		 *   wrapper around them (and thus no other way to tell they are related).
 		 *


### PR DESCRIPTION
Enables the support for forcing an element to be drawn as a block-level element if it has a wrapper. Also permits defining render methods with additional paramenters that are not related to overriding parameters.