### PR TITLE
bugfix-hhvmErrorHandling

### DIFF
--- a/assets/php/error_dump.php
+++ b/assets/php/error_dump.php
@@ -18,7 +18,12 @@
 $__exc_strMessageBody = htmlentities($__exc_strMessage, null, null, false);
 $__exc_strMessageBody = str_replace(" ", "&nbsp;", str_replace("\n", "<br/>\n", $__exc_strMessageBody));
 $__exc_strMessageBody = str_replace(":&nbsp;", ": ", $__exc_strMessageBody);
-$__exc_objFileArray = file($__exc_strFilename);
+
+if (file_exists($__exc_strFilename)) {
+	$__exc_objFileArray = file($__exc_strFilename);
+} else {
+	$__exc_objFileArray = array();
+}
 
 header("HTTP/1.1 500 Internal Server Error");
 ?>
@@ -110,10 +115,14 @@ if (stristr($__exc_strMessage, "Invalid Form State Data") !== false) {
 										$__exc_ObjSessionVarArray[$__exc_StrSessionKey] = $__exc_StrSessionValue;
 								}
 								$__exc_StrVarExport = htmlentities(var_export($__exc_ObjSessionVarArray, true));
-							} else if (($__exc_ObjVariableArray[$__exc_Key] instanceof QControl) || ($__exc_ObjVariableArray[$__exc_Key] instanceof QForm))
-								$__exc_StrVarExport = htmlentities($__exc_ObjVariableArray[$__exc_Key]->VarExport());
-							else
+							} else if (($__exc_ObjVariableArray[$__exc_Key] instanceof QControl) || ($__exc_ObjVariableArray[$__exc_Key] instanceof QForm)) {
+								if (!defined('HHVM_VERSION')) {
+									// var_export crashes hhvm currently
+									$__exc_StrVarExport = htmlentities($__exc_ObjVariableArray[$__exc_Key]->VarExport());
+								}
+							} else {
 								$__exc_StrVarExport = htmlentities(var_export($__exc_ObjVariableArray[$__exc_Key], true));
+							}
 
 							$__exc_StrToDisplay .= sprintf("<a style='display:block' href='#%s' onclick='javascript:ToggleHidden(\"%s\"); return false;'>%s</a>", $varCounter, $varCounter, $__exc_Key);
 							$__exc_StrToDisplay .= sprintf("<span id=\"%s\" style='display:none'>%s</span>", $varCounter, $__exc_StrVarExport);

--- a/includes/error.inc.php
+++ b/includes/error.inc.php
@@ -19,7 +19,7 @@
 		global $__exc_strType;
 		if (isset($__exc_strType))
 			return; // error was already called, avoid endless looping
-			
+
 		$__exc_objReflection = new ReflectionObject($__exc_objException);
 
 		$__exc_strType = "Exception";
@@ -60,7 +60,9 @@
 			// Error in installer or similar - ERROR_PAGE_PATH constant is not defined yet.
 			echo "error: errno: ". $__exc_errno . "<br/>" . $__exc_strMessage . "<br/>" . $__exc_strFilename . ":" . $__exc_intLineNumber . "<br/>" . $__exc_strStackTrace ;
 		}
-		exit();
+		if (!defined('HHVM_VERSION')) {
+			exit(); // HHVM bug. Will not display output if this gets executed here.
+		}
 	}
 
 	function QcodoHandleError($__exc_errno, $__exc_errstr, $__exc_errfile, $__exc_errline, $__exc_errcontext) {
@@ -192,6 +194,9 @@
 				''
 			);
 		}
+		//flush();	// required for hhvm
+		//error_log("Flushed");
+
 	}
 
 ?>


### PR DESCRIPTION
Fixing problems with HHVM when displaying error messages.

Also, note the following php.ini config setting:

``` hhvm.log.always_log_unhandled_exceptions = 0 ```

The default setting is 1, which will send all exceptions to the log file and will NOT execute the qcubed exception handler.