### PR TITLE
bugfix-Multilne

### DIFF
--- a/assets/php/tests/ui_basic.php
+++ b/assets/php/tests/ui_basic.php
@@ -97,9 +97,8 @@ class BasicForm extends QForm {
 	}
 
 	protected function submit_click($strFormId, $strControlId, $strParameter) {
-		$strTemp = $this->txtText->Text;
-		$this->txtText->Text = $this->txtText2->Text;
-		$this->txtText2->Text = $strTemp;
+		$this->txtText->Warning = 'Value = ' . $this->txtText->Text;
+		$this->txtText2->Warning = 'Value = ' . $this->txtText2->Text;
 
 		$this->chkCheck->Warning = 'Value = ' . $this->chkCheck->Checked;
 		$this->lstSelect->Warning = 'Value = ' . $this->lstSelect->SelectedValue;

--- a/includes/base_controls/QControlBase.class.php
+++ b/includes/base_controls/QControlBase.class.php
@@ -1502,9 +1502,9 @@
 				$strOutput = $this->GetControlHtml();
 
 				if ($this->strValidationError)
-					$strOutput .= sprintf('<br %s/><span %sclass="error">%s</span>', $strDataRel, $strDataRel, $this->strValidationError);
+					$strOutput .= sprintf('<br %s/><span %sclass="error">%s</span>', $strDataRel, $strDataRel, QHtml::RenderString($this->strValidationError));
 				else if ($this->strWarning)
-					$strOutput .= sprintf('<br %s/><span %sclass="warning">%s</span>', $strDataRel, $strDataRel, $this->strWarning);
+					$strOutput .= sprintf('<br %s/><span %sclass="warning">%s</span>', $strDataRel, $strDataRel, QHtml::RenderString($this->strWarning));
 			} catch (QCallerException $objExc) {
 				$objExc->IncrementOffset();
 				throw $objExc;
@@ -1570,9 +1570,9 @@
 			// Render the Right side
 			$strMessage = '';
 			if ($this->strValidationError){
-				$strMessage = sprintf('<span class="error">%s</span>', $this->strValidationError);
+				$strMessage = sprintf('<span class="error">%s</span>', QHtml::RenderString($this->strValidationError));
 			}else if ($this->strWarning){
-				$strMessage = sprintf('<span class="warning">%s</span>', $this->strWarning);
+				$strMessage = sprintf('<span class="warning">%s</span>', QHtml::RenderString($this->strWarning));
 			}
 			
 			try {

--- a/includes/base_controls/QTextBoxBase.class.php
+++ b/includes/base_controls/QTextBoxBase.class.php
@@ -165,7 +165,9 @@
 			// Check to see if this Control's Value was passed in via the POST data
 			if (array_key_exists($this->strControlId, $_POST)) {
 				// It was -- update this Control's value with the new value passed in via the POST arguments
-				$this->strText = $_POST[$this->strControlId];
+				$strText = $_POST[$this->strControlId];
+				$strText = str_replace("\r\n", "\n", $strText); // Convert posted newlines to PHP newlines
+				$this->strText = $strText;
 				
 				$this->Sanitize();
 				

--- a/includes/framework/QHtml.class.php
+++ b/includes/framework/QHtml.class.php
@@ -419,8 +419,6 @@
 		/**
 		 * Utility function to create a link, i.e. an "a" tag.
 		 *
-		 *
-		 *
 		 * @param string $strUrl URL to link to. Use MakeUrl or MailToUrl to create the URL.
 		 * @param string $strText The inner text. This WILL be escaped.
 		 * @param array $attributes Other html attributes to include in the tag
@@ -432,6 +430,15 @@
 				$strText = QApplication::HtmlEntities($strText);
 			}
 			return self::RenderTag("a", $attributes, $strText);
+		}
+
+		/**
+		 * Renders a PHP string as HTML text. Makes sure special characters are encoded, and <br /> tags are substituted
+		 * for newlines.
+		 * @param $strText
+		 */
+		public static function RenderString($strText) {
+			return nl2br(htmlspecialchars($strText, ENT_COMPAT | ENT_HTML5, QApplication::$EncodingType));
 		}
 
 	}


### PR DESCRIPTION
Fixing problem with submits of multi line text boxes. Extra lines were being added. This was caused by switching to HTML5 encoding. The fix is to convert \r\n combinations in post variables to a single newline.

This also fixes a potential security problem. Warnings and errors were being sent to the browser in the clear without encoding the text.