### PR TITLE
bugfix-DataGrid2ColumnCheckClick

### DIFF
--- a/includes/base_controls/QDataGrid2Base.class.php
+++ b/includes/base_controls/QDataGrid2Base.class.php
@@ -18,6 +18,12 @@ class QDataGrid2_SortEvent extends QEvent {
 
 /**
  * Class QDataGrid2
+ *
+ * @property  QClause 	$ExpandAsArray True if this node should be array expanded.
+ * @property  string 	$SortColumnId The id of the currently sorted column. Does not change if columns are re-ordered.
+ * @property  int 		$SortColumnIndex The index of the currently sorted column.
+ * @property  int 		$SortDirection SortAscending or SortDescending.
+ *
  */
 class QDataGrid2Base extends QSimpleTable
 {
@@ -114,6 +120,8 @@ class QDataGrid2Base extends QSimpleTable
 	 */
 	public function AddActions() {
 		$this->AddAction(new QSimpleTableCheckBoxColumn_ClickEvent(), new QAjaxControlAction ($this, 'CheckClick'));
+		$this->AddAction(new QSimpleTableCheckBoxColumn_ClickEvent(), new QStopPropagationAction()); // prevent check click from bubbling as a row click.
+
 		$this->AddAction(new QDataGrid2_SortEvent(), new QAjaxControlAction ($this, 'SortClick'));
 	}
 

--- a/includes/base_controls/QSimpleTableColumn.class.php
+++ b/includes/base_controls/QSimpleTableColumn.class.php
@@ -934,7 +934,7 @@
 	 * 
 	 * A column to display a virtual attribute from a database record.
 	 *
-	 * @property string Attribute 
+	 * @property string $Attribute
 	 */
 	class QVirtualAttributeColumn extends QAbstractSimpleTableDataColumn {
 		protected $strAttribute;
@@ -1017,11 +1017,13 @@
 	 * a cache variable. You would just give an id to each checkbox. This would cause internet traffic every time
 	 * a box is clicked.
 	 *
+	 * @property bool $ShowCheckAll
+	 *
 	 */
 	class QSimpleTableCheckBoxColumn extends QAbstractSimpleTableDataColumn {
 		protected $blnHtmlEntities = false;	// turn off html entities
 		protected $checkParamCallback = null;
-		protected $blnShowCheckAll;
+		protected $blnShowCheckAll = false;
 
 		/**
 		 * Returns a header cell with a checkbox. This could be used as a check all box. Override this and return
@@ -1225,5 +1227,3 @@
 			parent::__construct($intDelay, $strCondition, 'input[type="checkbox"]');
 		}
 	}
-
-?>


### PR DESCRIPTION
Prevents a checkbox click from bubbling as a row click. Also fixes some documentation.