### PR TITLE
bugfix-RedirectSessionVars

### DIFF
--- a/includes/framework/QApplicationBase.class.php
+++ b/includes/framework/QApplicationBase.class.php
@@ -610,6 +610,7 @@
 				}
 
 				// End the Response Script
+				session_write_close();
 				exit();
 			}
 		}


### PR DESCRIPTION
Adding session_write_close to make sure recently updated session variables get written to the session before exiting for a redirect.