### PR TITLE
bugfix-ReverseReferenceCodegen

### DIFF
--- a/includes/codegen/templates/db_orm/class_gen/qcubed_query_classes.tpl.php
+++ b/includes/codegen/templates/db_orm/class_gen/qcubed_query_classes.tpl.php
@@ -48,7 +48,7 @@
 <?php foreach ($objTable->ColumnArray as $objColumn) { ?>
      * @property-read QQColumnNode $<?= $objColumn->PropertyName ?>
 
-<?php if (($objColumn->Reference) && (!$objColumn->Reference->IsType)) { ?>
+<?php if ($objColumn->Reference) { ?>
      * @property-read QQNode<?= $objColumn->Reference->VariableType; ?> $<?= $objColumn->Reference->PropertyName ?>
 
 <?php } ?>

--- a/includes/codegen/templates/db_orm/panels/edit_create_objects.tpl.php
+++ b/includes/codegen/templates/db_orm/panels/edit_create_objects.tpl.php
@@ -7,6 +7,7 @@
 		$this-><?php echo $objCodeGen->ModelConnectorVariableName($objColumn);  ?> = $this->mct<?= $strPropertyName  ?>-><?php echo $objCodeGen->ModelConnectorVariableName($objColumn);  ?>_Create();
 <?php } ?>
 <?php foreach ($objTable->ReverseReferenceArray as $objReverseReference) { ?>
+<?php	if (isset ($objReverseReference->Options['FormGen']) && ($objReverseReference->Options['FormGen'] == 'none' || $objReverseReference->Options['FormGen'] == 'meta')) continue; ?>
 <?php if ($objReverseReference->Unique) { ?>
 		$this-><?php echo $objCodeGen->ModelConnectorVariableName($objReverseReference);  ?> = $this->mct<?= $strPropertyName ?>-><?php echo $objCodeGen->ModelConnectorVariableName($objReverseReference);  ?>_Create();
 <?php } ?>


### PR DESCRIPTION
Fixing problem with list objects created by reverse reference items. If the object was set to not be included in the connector, the panel was still trying to create it.