### PR TITLE
bugfix-NullDateOnly

### DIFF
--- a/includes/framework/QDateTime.class.php
+++ b/includes/framework/QDateTime.class.php
@@ -230,16 +230,14 @@
 			// User is requesting to force a particular type.
 			switch ($intType) {
 				case QDateTime::DateOnlyType:
-					$this->blnDateNull = false;
 					$this->blnTimeNull = true;
 					$this->ReinforceNullProperties();
 					return;
 				case QDateTime::TimeOnlyType:
 					$this->blnDateNull = true;
-					$this->blnTimeNull = false;
 					$this->ReinforceNullProperties();
 					return;
-				case QDateTime::DateAndTimeType:
+				case QDateTime::DateAndTimeType:	// forcing both a date and time type to not be null
 					$this->blnDateNull = false;
 					$this->blnTimeNull = false;
 					break;

--- a/includes/tests/qcubed-unit/QDateTimeTests.php
+++ b/includes/tests/qcubed-unit/QDateTimeTests.php
@@ -105,6 +105,27 @@ class QDateTimeTests extends QUnitTestCaseBase {
 		$dt2 = new QDateTime($strIso, null, QDateTime::TimeOnlyType);
 		$this->assertTrue($dt2->IsDateNull());
 		$this->assertFalse($dt2->IsTimeNull());
+
+		// null constructors
+
+		$dt2 = new QDateTime(null);
+		$this->assertTrue($dt2->IsDateNull());
+		$this->assertTrue($dt2->IsTimeNull());
+
+
+		$dt2 = new QDateTime(null, null, QDateTime::DateOnlyType);
+		$this->assertTrue($dt2->IsDateNull());
+		$this->assertTrue($dt2->IsTimeNull());
+
+		$dt2 = new QDateTime(null, null, QDateTime::TimeOnlyType);
+		$this->assertTrue($dt2->IsDateNull());
+		$this->assertTrue($dt2->IsTimeNull());
+
+		$dt2 = new QDateTime(null, null, QDateTime::DateAndTimeType);	// forcing it to have a date and time
+		$this->assertFalse($dt2->IsDateNull());
+		$this->assertFalse($dt2->IsTimeNull());
+
+
 	}
 
 	public function testTimeZoneIssues() {


### PR DESCRIPTION
Fixing an old problem where if you create a null QDateTime and specified you wanted it to be DateOnly, it would produce a non-null date at 2000-01-01. Same fix for TimeOnly too.