### PR TITLE
bugfix-StringifyObjects

### DIFF
--- a/includes/framework/QType.class.php
+++ b/includes/framework/QType.class.php
@@ -113,6 +113,10 @@
 
 				if ($objItem instanceof $strType)
 					return $objItem;
+
+				if ($strType == QType::String) {
+					return (string) $objItem;	// invokes __toString() magic method
+				}
 			} catch (Exception $objExc) {
 			}
 


### PR DESCRIPTION
Allow magic method to stringify objects if one is set. Currently, you get an error, even if __toString() is defined on an object.