### PR TITLE
bugfix-PersistantControlsAndRedirect

### DIFF
--- a/assets/php/examples/other_controls/persist.php
+++ b/assets/php/examples/other_controls/persist.php
@@ -28,7 +28,7 @@ class PersistentExampleForm extends QForm {
 	}
 
 	protected function btnReload_Click() {
-		QApplication::Redirect('persist.php', false); // Make sure the redirect does not abort the current script. Otherwise, the state of the controls will not be remembered.
+		QApplication::Redirect('persist.php');
 	}
 }
 

--- a/includes/base_controls/QFormBase.class.php
+++ b/includes/base_controls/QFormBase.class.php
@@ -930,7 +930,7 @@
 		/**
 		 * Tell all the controls to save their state.
 		 */
-		protected function SaveControlState() {
+		public function SaveControlState() {
 			// tell the controls to save their state
 			$a = $this->GetAllControls();
 			foreach ($a as $control) {

--- a/includes/framework/QApplicationBase.class.php
+++ b/includes/framework/QApplicationBase.class.php
@@ -589,6 +589,12 @@
 				QApplication::$JavascriptCommandArray[QAjaxResponse::Location] = $strLocation;
 			}
 			else {
+				global $_FORM;
+
+				if ($_FORM) {
+					$_FORM->SaveControlState();
+				}
+
 				// Clear the output buffer (if any)
 				ob_clean();
 


### PR DESCRIPTION
The current system has a problem, in that QApplication::Redirect will not save control states unless you add false as a second parameter. This fix will allow persistent controls to be saved even if you forget to do this.
