### PR TITLE
feature-ListColumns

### DIFF
--- a/includes/codegen/templates/db_orm/panels/_list_subclass.tpl.php
+++ b/includes/codegen/templates/db_orm/panels/_list_subclass.tpl.php
@@ -12,6 +12,9 @@
 		'TargetDirectory' => __PANEL__,
 		'TargetFileName' => $strPropertyName . 'ListPanel.class.php'
 	);
+
+	$listCodegenerator = $objCodeGen->GetDataListCodeGenerator($objTable);
+
 ?>
 <?php print("<?php\n"); ?>
 require(__PANEL_GEN__ . '/<?= $strPropertyName ?>ListPanelGen.class.php');
@@ -40,4 +43,13 @@ class <?= $strPropertyName ?>ListPanel extends <?= $strPropertyName ?>ListPanelG
 		$this->AutoRenderChildren = true;
 		//$this->Template =  __PANEL_GEN__ . '/<?= $strPropertyName ?>ListPanel.tpl.php';
 	}
+
+/*
+	Uncomment this block to directly create the columns here, rather than creating them from the <?= $strPropertyName ?>List connector.
+	You can then modify the column creation process by editing this function here.
+
+<?= $listCodegenerator->GenerateCreateColumnsOverride($objCodeGen, $objTable); ?>
+
+
+*/
 }


### PR DESCRIPTION
This is an important enhancement to the ListConnector generator I created recently. After using it for a while, I found it too limiting.

The problem is as follows:

We create a QDataGrid2 subclass to list the contents of a table. We then embed that data grid into a panel, which contains a filter, a new button, and anything else the developer might add to the list view. In some situations, the data grid can be thought of as a rather static view into the table that the developer would want to show with one particular set of columns and conditions, and reuse. In other situations, the developer would want to customize the columns and conditions for different views into the data. 

This new way of generating the list code accommodates both situations. The developer can either override functions at the data grid layer to customize the grid, or override functions at the parent panel layer.