### PR TITLE
Don't use output buffering when on cli

### DIFF
--- a/includes/qcubed.inc.php
+++ b/includes/qcubed.inc.php
@@ -49,12 +49,18 @@
 	// Setup the Error Handler
 	require(__QCUBED_CORE__ . '/error.inc.php');
 	
-	// Start Output Buffering	
+	// Start Output Buffering (only if not on commandline)	
 	function __ob_callback($strBuffer) {
 		return QApplication::OutputPage($strBuffer);
 	}
-	ob_start('__ob_callback');
-
+	
+	function isCommandLineInterface()
+	{
+		return (php_sapi_name() === 'cli');
+	}
+	if(!isCommandLineInterface()) {
+		ob_start('__ob_callback');
+	}
 	// Preload Other Framework Classes
 	require(__QCUBED_CORE__ . '/framework/QDatabaseBase.class.php');
 	require(__QCUBED_CORE__ . '/database/QPdoDatabase.class.php');


### PR DESCRIPTION
We usually run all qcubed applications in a webbrowser. But sometimes I'd like to write scripts with qcubed that I run on the command line. 
When executing a script on the command line, it makes little sense to buffer the output. You actually want the output straight away. 

I don't know if this change belongs in the core of qcubed, but I can't see how to change this in another manner.