### PR TITLE
bugfix-NamespacedEvents

### DIFF
--- a/includes/base_controls/_actions.inc.php
+++ b/includes/base_controls/_actions.inc.php
@@ -387,7 +387,7 @@
 			}
 
 			return sprintf("qc.pA('%s', '%s', '%s#%s', %s, '%s');",
-				$objControl->Form->FormId, $objControl->ControlId, get_class($this->objEvent), $this->strId, $this->getActionParameter($objControl), $strWaitIconControlId);
+				$objControl->Form->FormId, $objControl->ControlId, addslashes(get_class($this->objEvent)), $this->strId, $this->getActionParameter($objControl), $strWaitIconControlId);
 		}
 	}
 


### PR DESCRIPTION
Fixing bug where events defined in namespaces were not working. The problem was that backslashes used in defining the namespace path were being removed by the javascript side.