### PR TITLE
bugfix-HListItemParam

### DIFF
--- a/includes/base_controls/QControlBase.class.php
+++ b/includes/base_controls/QControlBase.class.php
@@ -420,17 +420,34 @@
 		}
 
 
+		public static function _ProcessActionParams(QControl $objSourceControl, QAction $objAction, $mixParameter) {
+			$mixParameters['param'] = null;
+			$mixParameters = $objSourceControl->ProcessActionParameters($objAction, $mixParameter);
+			return $mixParameters;
+		}
+
+		/**
+		 * @param $mixParameter
+		 * @return mixed
+		 */
+		protected function ProcessActionParameters(QAction $objAction, $mixParameter) {
+			$params['param'] = $mixParameter;	// this value can be modified by subclass if needed
+			$params['originalParam'] = $mixParameter;
+			$params['action'] = $objAction;
+			$params['controlId'] = $this->strControlId;
+			return $params;
+		}
+
 		/**
 		 * Used by the QForm engine to call the method in the control, allowing the method to be a protected method.
 		 *
-		 * @param QControl $objControl
-		 * @param $strMethodName
-		 * @param $strFormId
-		 * @param $strId
-		 * @param $strParameter
+		 * @param QControl $objDestControl
+		 * @param string $strMethodName
+		 * @param $strSourceControlId
+		 * @param mixed $mixParameter	Parameters coming from javascript
 		 */
-		public static function CallActionMethod(QControl $objControl, $strMethodName, $strFormId, $strId, $strParameter) {
-			$objControl->$strMethodName($strFormId, $strId, $strParameter);
+		public static function _CallActionMethod(QControl $objDestControl, $strMethodName, $strFormId, $params) {
+			$objDestControl->$strMethodName($strFormId, $params['controlId'], $params['param'], $params);
 		}
 
 		/**

--- a/includes/base_controls/QFormBase.class.php
+++ b/includes/base_controls/QFormBase.class.php
@@ -506,9 +506,7 @@
 				if (isset($_POST['Qform__FormControl']) && isset($objClass->objControlArray[$_POST['Qform__FormControl']])) {
 					$objControl = $objClass->objControlArray[$_POST['Qform__FormControl']];
 					if ($objControl->CausesValidation) {
-						foreach ($objClass->objControlArray as $objControl) {
-							$objControl->ValidationReset();
-						}
+						$objClass->ResetValidationStates();
 					}
 				}
 
@@ -612,6 +610,22 @@
 			$objClass->Form_Exit();
 		}
 
+		/**
+		 * Reset all validation states.
+		 */
+		public function ResetValidationStates() {
+			foreach ($this->objControlArray as $objControl) {
+				$objControl->ValidationReset();
+			}
+		}
+
+		/**
+		 * Private function to respond to a designer click.
+		 *
+		 * @param $strFormId
+		 * @param $strControlId
+		 * @param $mixParam
+		 */
 		private function ctlDesigner_Click ($strFormId, $strControlId, $mixParam) {
 			$objControl = $this->GetControl($strControlId);
 			$dlg = $this->GetControl ('qconnectoreditdlg');
@@ -1106,23 +1120,27 @@
 
 		/**
 		 * Triggers an event handler method for a given control ID
-		 * NOTE: Parameters must be already validated.
+		 * NOTE: Parameters must be already validated and are guaranteed to exist.
 		 *
-		 * @param string $strControlId  Control ID for which the method has to be triggered
-		 * @param string $strMethodName Method name which has to be fired
+		 * @param string $strControlId  Control ID triggering the method
+		 * @param string $strMethodName Method name which has to be fired. Includes a control id if a control action.
+		 * @param QAction $objAction The action object which caused the event
 		 */
-		protected function TriggerMethod($strControlId, $strMethodName) {
-			$strParameter = $_POST['Qform__FormParameter'];
+		protected function TriggerMethod($strControlId, $strMethodName, QAction $objAction) {
+			$mixParameter = $_POST['Qform__FormParameter'];
+			$objSourceControl = $this->objControlArray[$strControlId];
+			$params = QControl::_ProcessActionParams($objSourceControl, $objAction, $mixParameter);
 
 			$intPosition = strpos($strMethodName, ':');
 			if ($intPosition !== false) {
-				$strControlName = substr($strMethodName, 0, $intPosition);
+				$strDestControlId = substr($strMethodName, 0, $intPosition);
 				$strMethodName = substr($strMethodName, $intPosition + 1);
 
-				$objControl = $this->objControlArray[$strControlName];
-				QControl::CallActionMethod ($objControl, $strMethodName, $this->strFormId, $strControlId, $strParameter);
-			} else
-				$this->$strMethodName($this->strFormId, $strControlId, $strParameter);
+				$objDestControl = $this->objControlArray[$strDestControlId];
+				QControl::_CallActionMethod ($objDestControl, $strMethodName, $this->strFormId, $params);
+			} else {
+				$this->$strMethodName($this->strFormId, $params['controlId'], $params['param'], $params);
+			}
 		}
 
 		/**
@@ -1147,20 +1165,20 @@
 		protected function TriggerActions($strControlIdOverride = null) {
 			if (array_key_exists('Qform__FormControl', $_POST)) {
 				if ($strControlIdOverride) {
-					$strId = $strControlIdOverride;
+					$strControlId = $strControlIdOverride;
 				} else {
-					$strId = $_POST['Qform__FormControl'];
+					$strControlId = $_POST['Qform__FormControl'];
 				}
 
 				// Control ID determined
-				if ($strId != '') {
+				if ($strControlId != '') {
 					$strEvent = $_POST['Qform__FormEvent'];
 					$strAjaxActionId = NULL;
 
 					// Does this Control which performed the action exist?
-					if (array_key_exists($strId, $this->objControlArray)) {
+					if (array_key_exists($strControlId, $this->objControlArray)) {
 						// Get the ActionControl as well as the Actions to Perform
-						$objActionControl = $this->objControlArray[$strId];
+						$objActionControl = $this->objControlArray[$strControlId];
 
 						switch ($this->strCallType) {
 							case QCallType::Ajax:
@@ -1276,7 +1294,7 @@
 										|| ($objAction->Id == NULL) 		// or the QAjaxAction derived action has no id set
 										//(a possible way to add a callback that gets executed on every ajax call for this control)
 										|| ($strAjaxActionId == $objAction->Id)) //or the ajax action id passed from client side equals the id of the current ajax action
-										$this->TriggerMethod($strId, $strMethodName);
+										$this->TriggerMethod($strControlId, $strMethodName, $objAction);
 								}
 							}
 						}
@@ -1285,7 +1303,7 @@
 						}
 					} else {
 						// Nope -- Throw an exception
-						throw new Exception(sprintf('Control passed by Qform__FormControl does not exist: %s', $strId));
+						throw new Exception(sprintf('Control passed by Qform__FormControl does not exist: %s', $strControlId));
 					}
 				}
 				/* else {
@@ -1740,7 +1758,7 @@
 
 			// Register controls
 			if ($strControlIdToRegister) {
-				$strEndScript .= sprintf('qc.regCA(%s); ', JavaScriptHelper::toJsObject($strControlIdToRegister));
+				$strEndScript .= sprintf("qc.regCA(%s); \n", JavaScriptHelper::toJsObject($strControlIdToRegister));
 			}
 
 			// Add any application level js commands.

--- a/includes/base_controls/QHListControl.class.php
+++ b/includes/base_controls/QHListControl.class.php
@@ -111,10 +111,10 @@ class QHListControl extends QControl {
 	/**
 	 * Return the html to draw an item.
 	 *
-	 * @param QHListItem $objItem
+	 * @param mixed $objItem
 	 * @return string
 	 */
-	protected function GetItemHtml (QHListItem $objItem) {
+	protected function GetItemHtml ($objItem) {
 		$strHtml = $this->GetItemText($objItem);
 		$strHtml .= "\n";
 		if ($objItem->GetItemCount()) {
@@ -137,10 +137,10 @@ class QHListControl extends QControl {
 	/**
 	 * Return the text html of the item.
 	 *
-	 * @param QListItem $objItem
+	 * @param mixed $objItem
 	 * @return string
 	 */
-	protected function GetItemText (QHListItem $objItem) {
+	protected function GetItemText ($objItem) {
 		$strHtml = QApplication::HtmlEntities($objItem->Text);
 
 		if ($strAnchor = $objItem->Anchor) {
@@ -156,7 +156,7 @@ class QHListControl extends QControl {
 	 * @param QListItem $objItem
 	 * @return QListItemStyle
 	 */
-	protected function GetItemStyler (QHListItem $objItem) {
+	protected function GetItemStyler ($objItem) {
 		if ($this->objItemStyle) {
 			$objStyler = clone $this->objItemStyle;
 		}
@@ -204,10 +204,10 @@ class QHListControl extends QControl {
 
 	/**
 	 * Return the attributes for the sub tag that wraps the item tags
-	 * @param QListItem $objItem
-	 * @return null|array|string
+	 * @param mixed $objItem
+	 * @return array|null|string
 	 */
-	protected function GetSubTagAttributes(QHListItem $objItem) {
+	protected function GetSubTagAttributes($objItem) {
 		return $objItem->GetSubTagStyler()->RenderHtmlAttributes();
 	}
 

--- a/includes/base_controls/QHListControl.class.php
+++ b/includes/base_controls/QHListControl.class.php
@@ -153,7 +153,7 @@ class QHListControl extends QControl {
 	 * Return the item styler for the given item. Combines the generic item styles found in this class with
 	 * any specific item styles found in the item.
 	 *
-	 * @param QListItem $objItem
+	 * @param mixed $objItem
 	 * @return QListItemStyle
 	 */
 	protected function GetItemStyler ($objItem) {
@@ -179,10 +179,10 @@ class QHListControl extends QControl {
 	/**
 	 * Return the encrypted value of the given object
 	 *
-	 * @param QHListItem $objItem
+	 * @param mixed $objItem
 	 * @return string
 	 */
-	protected function EncryptValue(QHListItem $objItem) {
+	protected function EncryptValue($objItem) {
 		if (!$this->objCrypt) {
 			$this->objCrypt = new QCryptography(null, true);
 		}


### PR DESCRIPTION
Fixing problem with subclasses of QHListControl not being able to call functions correctly because of the unnecessary limit on the control type. Needed for work I am doing in the bootstrap plugin.