### PR TITLE
bugfix-RestoreListboxState

### DIFF
--- a/includes/base_controls/QListBoxBase.class.php
+++ b/includes/base_controls/QListBoxBase.class.php
@@ -205,6 +205,22 @@
 			QApplication::ExecuteControlCommand($this->ControlId, 'val', $values);
 		}
 
+		/**
+		 * Restore the  state of the control. This override makes sure the item exists before putting it. Otherwise,
+		 * if the item did not exist, the default selection would be removed and nothing would be selected.
+		 * @param mixed $state
+		 */
+		public function PutState($state) {
+			if (!empty($state['SelectedValues'])) {
+				// assume only one selection in list
+				$strValue = reset($state['SelectedValues']);
+				if ($this->FindItemByValue($strValue)) {
+					$this->SelectedValues = [$strValue];
+				}
+			}
+		}
+
+
 		/////////////////////////
 		// Public Properties: GET
 		/////////////////////////

--- a/includes/base_controls/QListItemManager.trait.php
+++ b/includes/base_controls/QListItemManager.trait.php
@@ -244,4 +244,20 @@
 
 			return $objFoundItem;
 		}
+
+		/**
+		 * Returns the first tiem found with the given value.
+		 *
+		 * @param $strValue
+		 * @return null|QListItemBase
+		 */
+		public function FindItemByValue($strValue) {
+			if (!$this->objListItemArray) return null;
+			foreach ($this->objListItemArray as $objItem) {
+				if ($objItem->Value == $strValue) {
+					return $objItem;
+				}
+			}
+			return null;
+		}
 	}


### PR DESCRIPTION
Minor listbox issue. Making sure item exists before setting it as the listbox selected value. Fixes a problem where if the current selection is deleted, then there will be no selection, rather than the default selection. Listboxes should always have something selected when possible.