### PR TITLE
RenderAsScript function added (port from qcubed2)

### DIFF
--- a/includes/base_controls/QControlProxy.class.php
+++ b/includes/base_controls/QControlProxy.class.php
@@ -152,10 +152,7 @@
 				$this->strTargetControlId = $this->objForm->GenerateControlId();
 			
 			$this->mixActionParameter = $strActionParameter;
-			$objActions = $this->GetAllActions('QClickEvent');
-			$strToReturn = '';
-			foreach ($objActions as $objAction)
-				$strToReturn .= $objAction->RenderScript($this);
+			$strToReturn = $this->RenderAsScript('QClickEvent');
 			if ($strToReturn)
 				$strToReturn = 'javascript:' . $strToReturn;
 			else
@@ -174,6 +171,15 @@
 			else
 				return $strToReturn;
 		}
+		
+		public function RenderAsScript($strEventType='QClickEvent') {
+ +			$objActions 	= $this->GetAllActions($strEventType);
+ +			$strToReturn 	= '';
+ +			foreach ($objActions as $objAction) {
+ +				$strToReturn .= $objAction->RenderScript($this);
+ +			}
+ +			return $strToReturn;
+ +		}
 
 		/**
 		 * Parses postback data


### PR DESCRIPTION
See item : RenderAsScript function added #945

If you use RenderAsHref you get onclick="qc.Pa... "; but if you want the raw javascript, you have to create this yourself.

I created a new function RenderAsScript which allows you to get the raw javascript action:
qc.Pa('FrontController','c62','QClickEvent',....