### PR TITLE
bugfix-ConnectorDialog

### DIFF
--- a/includes/codegen/QModelConnectorEditDlg.class.php
+++ b/includes/codegen/QModelConnectorEditDlg.class.php
@@ -360,7 +360,13 @@ class QModelConnectorEditDlg extends QDialog {
 			$type = QControlCategoryType::MultiSelect;
 		}
 		elseif ($node->_TableName) { // indicates a reference to a table
-			$type = QControlCategoryType::Table;
+			if ($node->_ParentNode) {
+				// A foreign key to another table
+				$type = QControlCategoryType::SingleSelect;
+			} else {
+				// A top level table, so a grid or list view
+				$type = QControlCategoryType::Table;
+			}
 		}
 
 		if (isset ($controls[$type])) {


### PR DESCRIPTION
Fixing problem with connector dialog. This is caused by earlier changes to how nodes work. It was no longer identifying direct foreign keys, and so could not load the right kind of controls.