### PR TITLE
bugfix-NumericValue

### DIFF
--- a/includes/base_controls/QFloatTextBox.class.php
+++ b/includes/base_controls/QFloatTextBox.class.php
@@ -9,7 +9,14 @@
 	 * A subclass of QNumericTextBox -- Validate will also ensure
 	 * that the Text is a valid float and (if applicable) is in the range of Minimum <= x <= Maximum
 	 *
+	 * We do not use the sanitize capability of QTextBox here. Sanitizing the data will change the data, and
+	 * if the user does not type in a valid float, we will not be able to put up a warning telling the user they made
+	 * a mistake. You can easily change this behavior by setting the following:
+	 * 	SanitizeFilter = FILTER_SANITIZE_NUMBER_FLOAT
+	 *  SanitizeFilterOptions = FILTER_FLAG_ALLOW_FRACTION
+	 *
 	 * @package Controls
+	 * @property int|null	 $Value			Returns the integer value of the text, sanitized.
 	 *
 	 */
 	class QFloatTextBox extends QNumericTextBox {
@@ -26,6 +33,25 @@
 			parent::__construct($objParentObject, $strControlId);
 			$this->strLabelForInvalid = QApplication::Translate('Invalid Float');
 			$this->strDataType = QType::Float;
+		}
+
+		public function __get($strName) {
+			switch ($strName) {
+				case "Value":
+					if ($this->strText === null || $this->strText === "") {
+						return null;
+					} else {
+						return (float)filter_var ($this->strText, FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION);
+					}
+
+				default:
+					try {
+						return parent::__get($strName);
+					} catch (QCallerException $objExc) {
+						$objExc->IncrementOffset();
+						throw $objExc;
+					}
+			}
 		}
 	}
 

--- a/includes/base_controls/QIntegerTextBox.class.php
+++ b/includes/base_controls/QIntegerTextBox.class.php
@@ -8,9 +8,13 @@
 	/**
 	 * A subclass of TextBox with its validate method overridden -- Validate will also ensure
 	 * that the Text is a valid integer and (if applicable) is in the range of Minimum <= x <= Maximum
+	 * 
+	 * We do not use the sanitize capability of QTextBox here. Sanitizing the data will change the data, and
+	 * if the user does not type in an integer, we will not be able to put up a warning telling the user they made
+	 * a mistake. You can easily change this behavior by setting SanitizeFilter = FILTER_SANITIZE_NUMBER_INT.
 	 *
 	 * @package Controls
-	 *
+	 * @property int|null	 $Value			Returns the integer value of the text, sanitized.
 	 */
 
 	class QIntegerTextBox extends QNumericTextBox {
@@ -28,6 +32,26 @@
 			$this->strLabelForInvalid = QApplication::Translate('Invalid Integer');
 			$this->strDataType = QType::Integer;
 		}
+
+		public function __get($strName) {
+			switch ($strName) {
+				case "Value": 
+					if ($this->strText === null || $this->strText === "") {
+						return null;
+					} else {
+						return (int)filter_var ($this->strText, FILTER_SANITIZE_NUMBER_INT);
+					}
+
+				default:
+					try {
+						return parent::__get($strName);
+					} catch (QCallerException $objExc) {
+						$objExc->IncrementOffset();
+						throw $objExc;
+					}
+			}
+		}
+
 	}
 
 ?>

--- a/includes/base_controls/QTextBoxBase.class.php
+++ b/includes/base_controls/QTextBoxBase.class.php
@@ -13,6 +13,8 @@
 	 * @property integer $Columns               is the "cols" html attribute (applicable for MultiLine textboxes)
 	 * @property string  $Format
 	 * @property string  $Text                  is the contents of the textbox, itself
+	 * @property string|null	 $Value			Returns the value of the text. If the text is empty, will return null.
+	 * 											Subclasses can use this to return a specific type of data.
 	 * @property string  $LabelForRequired
 	 * @property string  $LabelForRequiredUnnamed
 	 * @property string  $LabelForTooShort


### PR DESCRIPTION
There are ways to circumvent Validate, even accidentally. Overriding the Value attribute to return a sanitized version of the text box.