### PR TITLE
bugfix-CheckboxAjaxClickTiming

### DIFF
--- a/assets/js/qcubed.js
+++ b/assets/js/qcubed.js
@@ -966,6 +966,10 @@ qcubed.registerControl = function(mixControl) {
     }
 
     // detect changes to objects before any changes trigger other events
+    if (objControl.type === 'checkbox' || objControl.type === 'radio') {
+        // clicks are equivalent to changes for checkboxes and radio buttons, but some browsers send change way after a click. We need to capture the click first.
+        $j(objControl).on ('click', this.formObjChanged);
+    }
     $j(objControl).on ('change input', this.formObjChanged);
     $j(objControl).on ('change input', 'input, select, textarea', this.formObjChanged);   // make sure we get to bubbled events before later attached handlers
 

--- a/assets/php/tests/ui_ajax_timing.php
+++ b/assets/php/tests/ui_ajax_timing.php
@@ -1,0 +1,54 @@
+<?php
+    require_once('../qcubed.inc.php');
+
+/**
+ * Class AjaxTimingForm
+ *
+ * Tests the timing of ajax events and our ability to record a change to a control. There is a bit of a race condition
+ * that we need to get under control. For example, if the user clicks a checkbox that also has a "click" handler, and
+ * inside that handler, tests the value of the checkbox, the user should see the new value and not the one before the
+ * click.
+ */
+    
+	class AjaxTimingForm extends QForm {
+		protected $txt1;
+		protected $lblTxt1Change;
+		protected $lblTxt1KeyUp;
+
+		protected $chk;
+		protected $lblCheck;
+
+		protected function Form_Create() {
+			$this->txt1 = new QTextBox($this, 'txtbox');
+			$this->txt1->Name = "TextBox Test";
+			$this->txt1->Text = "Change me";
+			$this->txt1->AddAction(new QChangeEvent(), new QAjaxAction('txtChange'));
+			$this->txt1->AddAction(new QKeyUpEvent(), new QAjaxAction('txtKeyUp'));
+
+			$this->lblTxt1Change = new QLabel($this);
+			$this->lblTxt1Change->Name = "Value after Change";
+
+			$this->lblTxt1KeyUp = new QLabel($this);
+			$this->lblTxt1KeyUp->Name = "Value after Key Up";
+
+			$this->chk = new QCheckBox($this, 'chkbox');
+			$this->chk->Name = "Checkbox Text";
+			$this->chk->AddAction(new QClickEvent(), new QAjaxAction('chkChange'));
+			$this->lblCheck = new QLabel($this);
+			$this->lblCheck->Name = "Value after Click";
+		}
+
+		protected function txtChange($strFormId, $strControlId, $strParameter) {
+			$this->lblTxt1Change->Text = $this->txt1->Text;
+		}
+
+		protected function txtKeyUp($strFormId, $strControlId, $strParameter) {
+			$this->lblTxt1KeyUp->Text = $this->txt1->Text;
+		}
+
+		protected function chkChange($strFormId, $strControlId, $strParameter) {
+			$this->lblCheck->Text = $this->chk->Checked;
+		}
+
+	}
+AjaxTimingForm::Run('AjaxTimingForm');

--- a/assets/php/tests/ui_ajax_timing.tpl.php
+++ b/assets/php/tests/ui_ajax_timing.tpl.php
@@ -1,0 +1,13 @@
+<?php require(__PROJECT__ . '/includes/configuration/header.inc.php'); ?>
+<?php $this->RenderBegin(); ?>
+	<div>
+		<?php $this->txt1->RenderWithName(); ?>
+		<?php $this->lblTxt1Change->RenderWithName(); ?>
+		<?php $this->lblTxt1KeyUp->RenderWithName(); ?>
+	</div>
+	<div>
+		<?php $this->chk->RenderWithName(); ?>
+		<?php $this->lblCheck->RenderWithName(); ?>
+	</div>
+<?php $this->RenderEnd(); ?>
+<?php require(__PROJECT__ . '/includes/configuration/footer.inc.php'); ?>


### PR DESCRIPTION
Fix to a timing problem with checkboxes. This issue was probably the original reason for a checkbablecontrols hidden input and handler.

The problem is that for checkboxes and radio buttons, a "click" event is equivalent to a "change" event for our purposes. We want to be able to attach a click event to a checkbox, and during the action, see that the checkbox has changed. This was not happening for ajax handlers because the click would fire before the change, and so we would not post the change until the next ajax event.

This fix detects clicks on checkboxes and radio buttons, and then registers them as changed so that we send the value of the checkbox or radio button to the server along with any other event handlers.

This includes some test code to make sure it is working. The test was failing in the following way:
1) Load the page.
2) Click the checkbox. Result: no change
3) Click the checkbox two more times. Result: Now the label gets loaded with the value of the checkbox.

Expected: Step 2 should show the new value of the checkbox in the label.