### PR TITLE
bugfix-CheckableControlSetting

### DIFF
--- a/assets/js/qcubed.js
+++ b/assets/js/qcubed.js
@@ -936,6 +936,22 @@ qcubed.getWrapper = function(mixControl) {
     return objControl; //a wrapper-less control, return the control itself
 };
 
+/**
+ * Radio buttons are a little tricky to set if they are part of a group
+ * @param strControlId
+ */
+qcubed.setRadioInGroup = function(strControlId) {
+    var $objControl = $j('#' + strControlId);
+    if ($objControl) {
+        var groupName = $objControl.prop('name');
+        if (groupName) {
+            var $radios = $objControl.closest('form').find('input[type=radio][name=' + groupName + ']');
+            $radios.val([strControlId]);  // jquery does the work here of setting just the one control
+            $radios.trigger('qformObjChanged'); // send the new values back to the form
+        }
+    }
+}
+
 /////////////////////////////
 // Register Control - General
 /////////////////////////////

--- a/assets/php/tests/ui_basic.php
+++ b/assets/php/tests/ui_basic.php
@@ -124,6 +124,9 @@ class BasicForm extends QForm {
 		$this->lstSelect2->SelectedValues = [2,4];
 		$this->lstCheck2->SelectedValues = [1,3];
 		$this->lstRadio->SelectedIndex = 3;
+
+		$this->chkCheck->Checked = true;
+		$this->rdoRadio2->Checked = true;
 	}
 
 }

--- a/includes/base_controls/QCheckBox.class.php
+++ b/includes/base_controls/QCheckBox.class.php
@@ -233,21 +233,29 @@
 		 * @throws QInvalidCastException|QCallerException
 		 */
 		public function __set($strName, $mixValue) {
-			$this->blnModified = true;
-
 			switch ($strName) {
 				// APPEARANCE
+
 				case "Text":
 					try {
-						$this->strText = QType::Cast($mixValue, QType::String);
-						break;
+						$val = QType::Cast($mixValue, QType::String);
+						if ($val !== $this->strText) {
+							$this->strText = $val;
+							$this->blnModified = true;
+						}
+						return $this->strText;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
 						throw $objExc;
 					}
+
 				case "TextAlign":
 					try {
-						$this->strTextAlign = QType::Cast($mixValue, QType::String);
+						$val = QType::Cast($mixValue, QType::String);
+						if ($val !== $this->strTextAlign) {
+							$this->strTextAlign = $val;
+							$this->blnModified = true;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -266,7 +274,11 @@
 				// MISC
 				case "Checked":
 					try {
-						$this->blnChecked = QType::Cast($mixValue, QType::Boolean);
+						$val = QType::Cast($mixValue, QType::Boolean);
+						if ($val != $this->blnChecked) {
+							$this->blnChecked = $val;
+							$this->AddAttributeScript('prop', 'checked', $val);
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -278,6 +290,7 @@
 					try {
 						parent::__set($strName, $mixValue);
 						$this->getCheckLabelStyler()->CssClass = $mixValue; // assign to both checkbox and label so they can be styled together using css
+						$this->blnModified = true;
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();

--- a/includes/base_controls/QRadioButton.class.php
+++ b/includes/base_controls/QRadioButton.class.php
@@ -141,6 +141,23 @@
 						throw $objExc;
 					}
 
+				case "Checked":
+					try {
+						$val = QType::Cast($mixValue, QType::Boolean);
+						if ($val != $this->blnChecked) {
+							$this->blnChecked = $val;
+							if ($this->GroupName && $val == true) {
+								QApplication::ExecuteJsFunction('qcubed.setRadioInGroup', $this->strControlId);
+							} else {
+								$this->AddAttributeScript('prop', 'checked', $val); // just set the one radio
+							}
+						}
+						break;
+					} catch (QInvalidCastException $objExc) {
+						$objExc->IncrementOffset();
+						throw $objExc;
+					}
+
 				default:
 					try {
 						parent::__set($strName, $mixValue);


### PR DESCRIPTION
Fixing up some minor issues:
- Setting attributes of checkboxes to values such that the value does not change should not cause a redraw.
- Setting the checked state of both radios and checkboxes is now handled with javascript, so no redraw needed here either.