### PR TITLE
bugfix->ReverseReferencesOfForwardExpansions

### DIFF
--- a/includes/codegen/QDatabaseCodeGen.class.php
+++ b/includes/codegen/QDatabaseCodeGen.class.php
@@ -1003,7 +1003,7 @@
 									$objReverseReference->Options = $this->objModelConnectorOptions->GetOptions($objReference->VariableType, $objReverseReference->ObjectDescription);
 								}
 
-
+								$objReference->ReverseReference = $objReverseReference;	 // Let forward reference also see things from the other side looking back
 
 								// Add this ReverseReference to the referenced table's ReverseReferenceArray
 								$objArray = $objReferencedTable->ReverseReferenceArray;

--- a/includes/codegen/QReference.class.php
+++ b/includes/codegen/QReference.class.php
@@ -11,6 +11,7 @@
 	 * @property string $VariableName
 	 * @property string $VariableType
 	 * @property boolean $IsType
+	 * @property QReverseReference ReverseReference
 	 */
 	class QReference extends QBaseClass {
 
@@ -65,6 +66,13 @@
 		 */
 		protected $blnIsType;
 
+		/**
+		 * The reverse reference pointing back to this reference.
+		 *
+		 * @var QReverseReference
+		 */
+		protected $objReverseReference;
+
 
 
 
@@ -97,6 +105,8 @@
 					return $this->strVariableType;
 				case 'IsType':
 					return $this->blnIsType;
+				case 'ReverseReference':
+					return $this->objReverseReference;
 				default:
 					try {
 						return parent::__get($strName);
@@ -134,6 +144,8 @@
 						return $this->strVariableType = QType::Cast($mixValue, QType::String);
 					case 'IsType':
 						return $this->blnIsType = QType::Cast($mixValue, QType::Boolean);
+					case 'ReverseReference':
+						return $this->objReverseReference = $mixValue;
 					default:
 						return parent::__set($strName, $mixValue);
 				}

--- a/includes/codegen/templates/db_orm/class_gen/instantiation_methods.tpl.php
+++ b/includes/codegen/templates/db_orm/class_gen/instantiation_methods.tpl.php
@@ -25,8 +25,8 @@
 		 * @param QBaseClass $objPreviousItemArray Used by expansion code to aid in expanding arrays
 		 * @param string[] $strColumnAliasArray Array of column aliases mapping names in the query to items in the object
 		 * @param boolean $blnCheckDuplicate Used by ExpandArray to indicate we should not create a new object if this is a duplicate of a previoius object
-		 * @param boolean $strParentExpansionKey If this is part of an expansion, indicates what the parent item is
-		 * @param boolean $strParentExpansionObject If this is part of an expansion, is the object corresponding to the key so that we can refer back to the parent object
+		 * @param string $strParentExpansionKey If this is part of an expansion, indicates what the parent item is
+		 * @param boolean $objExpansionParent If this is part of an expansion, is the object corresponding to the key so that we can refer back to the parent object
 		 * @return mixed Either a <?= $objTable->ClassName ?>, or false to indicate the dbrow was used in an expansion, or null to indicate that this leaf is a duplicate.
 		*/
 		public static function InstantiateDbRow(
@@ -37,7 +37,7 @@
 				$strColumnAliasArray = array(),
 				$blnCheckDuplicate = false,
 				$strParentExpansionKey = null,
-				$objParentExpansionObject = null) {
+				$objExpansionParent = null) {
 			// If blank row, return null
 			if (!$objDbRow) {
 				return null;
@@ -156,8 +156,8 @@
 				$objExpansionNode = (empty($objExpansionAliasArray['<?= $objColumn->Name ?>']) ? null : $objExpansionAliasArray['<?= $objColumn->Name ?>']);
 				$objToReturn-><?= $objColumn->Reference->VariableName ?> = <?= $objColumn->Reference->VariableType ?>::InstantiateDbRow($objDbRow, $strAliasPrefix . '<?= $objColumn->Name ?>__', $objExpansionNode, null, $strColumnAliasArray, false, '<?= strtolower($objColumn->Reference->ReverseReference->ObjectDescription) ?>', $objToReturn);
 			}
-		    elseif ($strParentExpansionKey === '<?= $objColumn->Name ?>' && $objParentExpansionObject) {
-				$objToReturn-><?= $objColumn->Reference->VariableName ?> = $objParentExpansionObject;
+		    elseif ($strParentExpansionKey === '<?= $objColumn->Name ?>' && $objExpansionParent) {
+				$objToReturn-><?= $objColumn->Reference->VariableName ?> = $objExpansionParent;
 		    }
 
 	<?php } ?>
@@ -201,8 +201,8 @@
 					$objToReturn-><?= $varPrefix . $objReference->ObjectDescription ?> = <?= $objReference->VariableType ?>::InstantiateDbRow($objDbRow, $strAliasPrefix . '<?= strtolower($objReference->ObjectDescription) ?>__<?= $objReference->OppositeColumn ?>__', $objExpansionNode, null, $strColumnAliasArray, false, '<?= strtolower($objReference->OppositeObjectDescription) ?>', $objToReturn);
 				}
 			}
-			elseif ($strParentExpansionKey === '<?= strtolower($objReference->ObjectDescription) ?>' && $objParentExpansionObject) {
-				$objToReturn-><?= $varPrefix . $objReference->ObjectDescription ?> = $objParentExpansionObject;
+			elseif ($strParentExpansionKey === '<?= strtolower($objReference->ObjectDescription) ?>' && $objExpansionParent) {
+				$objToReturn-><?= $varPrefix . $objReference->ObjectDescription ?> = $objExpansionParent;
 			}
 
 <?php } ?>
@@ -222,8 +222,8 @@
 					$objToReturn->_obj<?= $objReference->ObjectDescription ?> = <?= $objReference->VariableType ?>::InstantiateDbRow($objDbRow, $strAliasPrefix . '<?= strtolower($objReference->ObjectDescription) ?>__', $objExpansionNode, null, $strColumnAliasArray, false, '<?= $objReference->Column ?>', $objToReturn);
 				}
 			}
-			elseif ($strParentExpansionKey === '<?= strtolower($objReference->ObjectDescription) ?>' && $objParentExpansionObject) {
-				$objToReturn->_obj<?= $objReference->ObjectDescription ?> = $objParentExpansionObject;
+			elseif ($strParentExpansionKey === '<?= strtolower($objReference->ObjectDescription) ?>' && $objExpansionParent) {
+				$objToReturn->_obj<?= $objReference->ObjectDescription ?> = $objExpansionParent;
 			}
 
 <?php } ?><?php } ?>

--- a/includes/codegen/templates/db_orm/class_gen/instantiation_methods.tpl.php
+++ b/includes/codegen/templates/db_orm/class_gen/instantiation_methods.tpl.php
@@ -26,7 +26,7 @@
 		 * @param string[] $strColumnAliasArray Array of column aliases mapping names in the query to items in the object
 		 * @param boolean $blnCheckDuplicate Used by ExpandArray to indicate we should not create a new object if this is a duplicate of a previoius object
 		 * @param string $strParentExpansionKey If this is part of an expansion, indicates what the parent item is
-		 * @param boolean $objExpansionParent If this is part of an expansion, is the object corresponding to the key so that we can refer back to the parent object
+		 * @param mixed $objExpansionParent If this is part of an expansion, is the object corresponding to the key so that we can refer back to the parent object
 		 * @return mixed Either a <?= $objTable->ClassName ?>, or false to indicate the dbrow was used in an expansion, or null to indicate that this leaf is a duplicate.
 		*/
 		public static function InstantiateDbRow(


### PR DESCRIPTION
There is a problem in how expansions are done currently, in that when you expand on a foreign key, and then with the object, look across the foreign key, and then look back, you see a null, which causes a Load to happen, and which loads a copy of the object looking backwards.

In other words, 

```
		$clauses = [QQ::Expand(QQN::Person()->ProjectAsManager)];
		$objPerson = Person::QuerySingle(QQ::All(), $clauses);
		$objProject = $objPerson->ProjectAsManager;
		$objPerson2 = $objProject->ManagerPerson;
```
$objPerson2 is not the same as $objPerson, plus an extra hidden query gets executed to fill in ManagerPerson when you ask for it. This can make some tables very slow to load, and make complex relationships difficult to manage.

This pull request fixes things so that $objPerson2 will be a reference to the same object as $objPerson, and makes it so that whenever you do a forward expansion, the matching reverse expansion is immediately and automatically populated with the forward looking object, so no additional query is generated.

You can still override this behavior by simply adding an expansion clause across the reverse reference. For example, adding:
```
$clauses = [QQ::Expand(QQN::Person()->ProjectAsManager->ManagerPerson)];
```
will cause $objPerson2 to again be a copy of $objPerson, instead of the same object.
