### PR TITLE
bugfix-QueryArrayAndSingleReturnTypes

### DIFF
--- a/includes/codegen/templates/db_orm/class_gen/qcubed_query_methods.tpl.php
+++ b/includes/codegen/templates/db_orm/class_gen/qcubed_query_methods.tpl.php
@@ -1,8 +1,31 @@
-	// See QModelBase.class.php
-	// protected static function BuildQueryStatement(&$objQueryBuilder, QQCondition $objConditions, $objOptionalClauses, $mixParameterArray, $blnCountOnly) {
-	// public static function QuerySingle(QQCondition $objConditions, $objOptionalClauses = null, $mixParameterArray = null) {
-	// public static function QueryArray(QQCondition $objConditions, $objOptionalClauses = null, $mixParameterArray = null) {
-	// public static function QueryCursor(QQCondition $objConditions, $objOptionalClauses = null, $mixParameterArray = null) {
-	// public static function QueryCount(QQCondition $objConditions, $objOptionalClauses = null, $mixParameterArray = null) {
-	// public static function QueryArrayCached(QQCondition $objConditions, $objOptionalClauses = null, $mixParameterArray = null, $blnForceUpdate = false) {
+
+		/**
+		 * Static Qcubed Query method to query for a single <?= $objTable->ClassName ?> object.
+		 * Offloads work to QModelTrait.trait.php
+		 * @param QQCondition $objConditions any conditions on the query, itself
+		 * @param QQClause[] $objOptionalClausees additional optional QQClause objects for this query
+		 * @param mixed[] $mixParameterArray a array of name-value pairs to perform PrepareStatement with
+		 * @return <?= $objTable->ClassName ?> the queried object
+		 */
+		public static function QuerySingle(QQCondition $objConditions, $objOptionalClauses = null, $mixParameterArray = null) {
+			return static::_QuerySingle($objConditions, $objOptionalClauses, $mixParameterArray);
+		}
+
+		/**
+		 * Static Qcubed Query method to query for an array of <?= $objTable->ClassName ?> objects.
+		 * Offloads work to QModelTrait.trait.php
+		 * @param QQCondition $objConditions any conditions on the query, itself
+		 * @param QQClause[] $objOptionalClausees additional optional QQClause objects for this query
+		 * @param mixed[] $mixParameterArray a array of name-value pairs to perform PrepareStatement with
+		 * @return <?= $objTable->ClassName ?>[] the queried objects as an array
+		 */
+		public static function QueryArray(QQCondition $objConditions, $objOptionalClauses = null, $mixParameterArray = null) {
+			return static::_QueryArray($objConditions, $objOptionalClauses, $mixParameterArray); 
+		}
+
+		// See QModelTrait.trait.php for the following
+		// protected static function BuildQueryStatement(&$objQueryBuilder, QQCondition $objConditions, $objOptionalClauses, $mixParameterArray, $blnCountOnly) {
+		// public static function QueryCursor(QQCondition $objConditions, $objOptionalClauses = null, $mixParameterArray = null) {
+		// public static function QueryCount(QQCondition $objConditions, $objOptionalClauses = null, $mixParameterArray = null) {
+		// public static function QueryArrayCached(QQCondition $objConditions, $objOptionalClauses = null, $mixParameterArray = null, $blnForceUpdate = false) {
 

--- a/includes/framework/QModelTrait.trait.php
+++ b/includes/framework/QModelTrait.trait.php
@@ -165,6 +165,8 @@ trait QModelTrait {
 	/**
 	 * Static Qcubed Query method to query for a single <?php echo $objTable->ClassName  ?> object.
 	 * Uses BuildQueryStatment to perform most of the work.
+	 * Is called by QuerySincle function of each object so that the correct return type will be put in the comments.
+	 * 
 	 * @param QQCondition $objConditions any conditions on the query, itself
 	 * @param null $objOptionalClauses
 	 * @param mixed[] $mixParameterArray a array of name-value pairs to perform PrepareStatement with
@@ -172,7 +174,7 @@ trait QModelTrait {
 	 * @throws QCallerException
 	 * @return null|QModelBase the queried object
 	 */
-	public static function QuerySingle(QQCondition $objConditions, $objOptionalClauses = null, $mixParameterArray = null) {
+	protected static function _QuerySingle(QQCondition $objConditions, $objOptionalClauses = null, $mixParameterArray = null) {
 		// Get the Query Statement
 		try {
 			$strQuery = static::BuildQueryStatement($objQueryBuilder, $objConditions, $objOptionalClauses, $mixParameterArray, false);
@@ -218,6 +220,7 @@ trait QModelTrait {
 	/**
 	 * Static Qcubed Query method to query for an array of objects.
 	 * Uses BuildQueryStatment to perform most of the work.
+	 * Is called by QueryArray function of each object so that the correct return type will be put in the comments.
 	 *
 	 * @param QQCondition $objConditions any conditions on the query, itself
 	 * @param QQClause[]|null $objOptionalClauses additional optional QQClause objects for this query
@@ -226,7 +229,7 @@ trait QModelTrait {
 	 * @throws Exception
 	 * @throws QCallerException
 	 */
-	public static function QueryArray(QQCondition $objConditions, $objOptionalClauses = null, $mixParameterArray = null) {
+	protected static function _QueryArray(QQCondition $objConditions, $objOptionalClauses = null, $mixParameterArray = null) {
 		// Get the Query Statement
 		try {
 			$strQuery = static::BuildQueryStatement($objQueryBuilder, $objConditions, $objOptionalClauses, $mixParameterArray, false);


### PR DESCRIPTION
Fixes QueryArray and QuerySingle so that the correct return type for each object will be put in the phpdoc comments. Makes is easier to use in editors.