### PR TITLE
bugfix-VarExport

### DIFF
--- a/assets/php/error_dump.php
+++ b/assets/php/error_dump.php
@@ -116,10 +116,7 @@ if (stristr($__exc_strMessage, "Invalid Form State Data") !== false) {
 								}
 								$__exc_StrVarExport = htmlentities(var_export($__exc_ObjSessionVarArray, true));
 							} else if (($__exc_ObjVariableArray[$__exc_Key] instanceof QControl) || ($__exc_ObjVariableArray[$__exc_Key] instanceof QForm)) {
-								if (!defined('HHVM_VERSION')) {
-									// var_export crashes hhvm currently
-									$__exc_StrVarExport = htmlentities($__exc_ObjVariableArray[$__exc_Key]->VarExport());
-								}
+								$__exc_StrVarExport = htmlentities($__exc_ObjVariableArray[$__exc_Key]->VarExport());
 							} else {
 								$__exc_StrVarExport = htmlentities(var_export($__exc_ObjVariableArray[$__exc_Key], true));
 							}

--- a/includes/base_controls/QControlBase.class.php
+++ b/includes/base_controls/QControlBase.class.php
@@ -1784,8 +1784,18 @@
 				$this->objForm = $this->objForm->FormId;
 			if ($this->objParentControl)
 				$this->objParentControl = $this->objParentControl->ControlId;
-			if ($blnReturn)
+
+			// In order to make the control exportable, we can't have circular references or things that are not exportable.
+			// We use the sleep helper as an aid to deep exporting the object.
+
+			$vars = get_object_vars($this);
+			foreach ($vars as $key=>$val) {
+				$this->$key = self::SleepHelper($val);
+			}
+
+			if ($blnReturn) {
 				return var_export($this, true);
+			}
 		}
 
 		/**


### PR DESCRIPTION
Fixing situations where a control might not be exportable. QCubed will just fail silently in these situations. This fix restores QCubed's ability to catch certain errors. It also fixes the problem where HHVM can't export controls.