### PR TITLE
bugfix-characterEncoding

### DIFF
--- a/assets/js/qcubed.js
+++ b/assets/js/qcubed.js
@@ -21,7 +21,7 @@ $j.fn.extend({
  * Queued Ajax requests.
  * A new Ajax request won't be started until the previous queued
  * request has finished.
- * @param object o Options.
+ * @param {object} o Options.
  */
 $j.ajaxQueue = function(o) {
     if (typeof $j.ajaxq === "undefined") {
@@ -40,7 +40,7 @@ qcubed = {
     /**
      * @param {string} strControlId
      * @param {string} strProperty
-     * @param {string} strNewValue
+     * @param {string|ARray|Object} strNewValue
      */
     recordControlModification: function(strControlId, strProperty, strNewValue) {
         if (!qcubed.controlModifications[strControlId]) {
@@ -116,7 +116,7 @@ qcubed = {
      * @param {string} strForm The QForm Id, gets overwritten.
      * @param {string} strControl The Control Id.
      * @param {string} strEvent The Event.
-     * @param {mixed} mixParameter
+     * @param {null|string|Array|Object} mixParameter
      */
     postBack: function(strForm, strControl, strEvent, mixParameter) {
         strForm = $j("#Qform__FormId").val();
@@ -159,7 +159,7 @@ qcubed = {
      * additional post variables. Multiple sets of the same value will overwrite previous value.
      *
      * @param {string} name Name to post. Should probably be the control id, but can be anything.
-     * @param {mixed} val  Any value you want to send to PHP. Can be a string, array or simple object. Can also contain null
+     * @param {null|number|string|Array|Object} val  Any value you want to send to PHP. Can be a string, array or simple object. Can also contain null
      * values and these will become nulls in PHP.
      */
     setAdditionalPostVar: function (name, val) {
@@ -198,7 +198,7 @@ qcubed = {
         if (!controls || controls.length == 0) {
             return {};
         }
-        $j.each(controls, function(i) {
+        $j.each(controls, function() {
             var $element = $j(this),
                 id = $element.attr("id"),
                 strType = $element.prop("type"),
@@ -255,7 +255,7 @@ qcubed = {
      * @param {string} strForm The Form Id
      * @param {string} strControl The Control Id
      * @param {string} strEvent The Event
-     * @param {mixed} mixParameter An array of parameters or a string value.
+     * @param {null|string|array|object} mixParameter An array of parameters or a string value.
      * @param {string} strWaitIconControlId Not used, probably legacy code.
      * @return {object} Post Data
      */
@@ -355,7 +355,7 @@ qcubed = {
      * @param {string} strForm The QForm Id
      * @param {string} strControl The Control Id
      * @param {string} strEvent
-     * @param {mixed} mixParameter
+     * @param {null|string|Object|Array} mixParameter
      * @param {string} strWaitIconControlId The id of the control's spinner.
      * @return {void}
      * @todo There is an eval() in here. We need to find a way around that.
@@ -372,7 +372,7 @@ qcubed = {
         qFormParams.waitIcon = strWaitIconControlId;
 
         if (strWaitIconControlId) {
-            this.objAjaxWaitIcon = this.getWrapper(strWaitIconControlId);
+            this.objAjaxWaitIcon = qcubed.getWrapper(strWaitIconControlId);
             if (this.objAjaxWaitIcon) {
                 this.objAjaxWaitIcon.style.display = 'inline';
             }
@@ -731,7 +731,7 @@ qcubed = {
             }
         }
         else if ($j.type(obj) == 'object') {
-            var newItem = {}
+            var newItem = {};
             $j.each (obj, function (key, obj2) {
                 newItem[key] = qcubed.unpackObj(obj2);
             });
@@ -808,7 +808,7 @@ qcubed.updateForm = function() {
         // delay to let multiple fast actions only trigger periodic refreshes
         qcubed.setTimeout ('qcubed.update', 'qcubed.updateForm', qcubed.minUpdateInterval);
     }
-}
+};
 
 /////////////////////////////////////
 // Drag and drop support
@@ -823,13 +823,13 @@ qcubed.draggable = function (parentId, draggableId) {
         var c = jQuery(this);
         qcubed.recordControlModification(draggableId, "_DragData", {originalPosition: {left: c.data("originalPosition").left, top: c.data("originalPosition").top}, position: {left: c.position().left, top: c.position().top}});
     });
-}
+};
 
 qcubed.droppable = function (parentId, droppableId) {
     jQuery('#' + parentId).on("drop", function (event, ui) {
         qcubed.recordControlModification(droppableId, "_DroppedId", ui.draggable.attr("id"));
     })
-}
+};
 
 qcubed.resizable = function (parentId, resizeableId) {
     $j('#' + parentId).on("resizestart", function () {
@@ -858,20 +858,20 @@ qcubed.dialog = function(controlId) {
             event.preventDefault();
         }
     });
-}
+};
 
 qcubed.accordion = function(controlId) {
     $j('#' + controlId).on("accordionactivate", function(event, ui) {
         qcubed.recordControlModification(controlId, "_SelectedIndex", $j(this).accordion("option", "active"));
         $j(this).trigger("change");
     });
-}
+};
 
 qcubed.progressbar = function(controlId) {
     $j('#' + controlId).on("progressbarchange", function (event, ui) {
         qcubed.recordControlModification(controlId, "_Value", $j(this).progressbar ("value"));
     });
-}
+};
 
 qcubed.selectable = function(controlId) {
     $j('#' + controlId).on("selectablestop", function (event, ui) {
@@ -888,7 +888,7 @@ qcubed.selectable = function(controlId) {
         qcubed.recordControlModification(controlId, "_SelectedItems", strItems);
 
     });
-}
+};
 
 qcubed.slider = function(controlId) {
     $j('#' + controlId).on("slidechange", function (event, ui) {
@@ -898,7 +898,7 @@ qcubed.slider = function(controlId) {
             qcubed.recordControlModification(controlId, "_Value", ui.value);
         }
     });
-}
+};
 
 qcubed.tabs = function(controlId) {
     $j('#' + controlId).on("tabsactivate", function(event, ui) {
@@ -906,44 +906,15 @@ qcubed.tabs = function(controlId) {
         var id = ui.newPanel ? ui.newPanel.attr("id") : null;
         qcubed.recordControlModification(controlId, "_active", [i,id]);
     });
-}
+};
 
 qcubed.datagrid2 = function(controlId) {
     $j('#' + controlId).on("click", "thead tr th a", function(event, ui) {
         var cellIndex = $j(this).parent()[0].cellIndex;
         $j(this).trigger('qdg2sort', cellIndex); // Triggers the QDataGrid2_SortEvent
     });
-}
-
-
-/////////////////////////////////////
-// Event Object-related functionality
-/////////////////////////////////////
-
-// You may still use this function but be advised
-// we no longer use it in core.  All event terminations
-// and event bubbling are handled through jQuery.
-// see http://trac.qcu.be/projects/qcubed/ticket/681
-/**
- * @deprecated
- */
-qcubed.terminateEvent = function(objEvent) {
-    objEvent = qcubed.handleEvent(objEvent);
-
-    if (objEvent) {
-        // Stop Propogation
-        if (objEvent.preventDefault) {
-            objEvent.preventDefault();
-        }
-        if (objEvent.stopPropagation) {
-            objEvent.stopPropagation();
-        }
-        objEvent.cancelBubble = true;
-        objEvent.returnValue = false;
-    }
-
-    return false;
 };
+
 
 /////////////////////////////////
 // Controls-related functionality
@@ -987,7 +958,7 @@ qcubed.setRadioInGroup = function(strControlId) {
             $radios.trigger('qformObjChanged'); // send the new values back to the form
         }
     }
-}
+};
 
 /////////////////////////////
 // Register Control - General
@@ -998,6 +969,7 @@ qcubed.javascriptStyleToQcubed = {};
 qcubed.formObjsModified = {};
 qcubed.additionalPostVars = {};
 qcubed.ajaxError = false;
+qcubed.inputSupport = true;
 qcubed.javascriptStyleToQcubed.backgroundColor = "BackColor";
 qcubed.javascriptStyleToQcubed.borderColor = "BorderColor";
 qcubed.javascriptStyleToQcubed.borderStyle = "BorderStyle";
@@ -1112,9 +1084,10 @@ qcubed.registerControl = function(mixControl) {
                 if (qcubed.javascriptStyleToQcubed[strStyleName]) {
                     qcubed.recordControlModification(objControl.id, qcubed.javascriptStyleToQcubed[strStyleName], strNewValue);
                 }
+                /* ???
                 if (this.handle) {
                     this.updateHandle();
-                }
+                }*/
                 break;
 
             case "text":

--- a/assets/js/qcubed.js
+++ b/assets/js/qcubed.js
@@ -104,6 +104,12 @@ qcubed = {
      */
     initForm: function (strFormId) {
         $j('#' + strFormId).on ('qformObjChanged', this.formObjChanged); // Allow any control, including hidden inputs, to trigger a change and post of its data.
+        $j('#' + strFormId).submit(function(event) {
+            if (!$j('#Qform__FormControl').val()) { // did postBack initiated the submit?
+                // if not, prevent implicit form submission. This can happen in the rare case we have a single field and no submit button.
+                event.preventDefault();
+            }
+        });
     },
 
     /**
@@ -116,29 +122,33 @@ qcubed = {
         strForm = $j("#Qform__FormId").val();
         var $objForm = $j('#' + strForm);
 
-        mixParameter = $j.param({obj: mixParameter}); // serialize in a way that can handle a string, array or object
-
         var checkableControls = $j('#' + strForm).find('input[type="checkbox"], input[type="radio"]');
         var checkableValues = this._checkableControlValues(strForm, $j.makeArray(checkableControls));
 
-
         $j('#Qform__FormControl').val(strControl);
         $j('#Qform__FormEvent').val(strEvent);
-        $j('#Qform__FormParameter').val(mixParameter);
         $j('#Qform__FormCallType').val("Server");
-        $j('#Qform__FormUpdates').val($j.param(qcubed.controlModifications));
-        $j('#Qform__FormCheckableControls').val($j.param(checkableValues));
 
         // Notify custom controls that we are about to post
         $objForm.trigger("qposting", "Server");
 
-        // add hidden control for the values given
-        // Will be decoded and assigned to the $_POST var in PHP. In ajax, its not needed
-        if (qcubed.additionalPostVars && qcubed.additionalPostVars.length) {
-            var input = $("<input>")
+        if (mixParameter !== undefined) {
+            $j('#Qform__FormParameter').val(JSON.stringify(mixParameter));
+        }
+        if (!$j.isEmptyObject(qcubed.controlModifications)) {
+            $j('#Qform__FormUpdates').val(JSON.stringify(qcubed.controlModifications));
+        }
+        if (!$j.isEmptyObject(checkableValues)) {
+            $j('#Qform__FormCheckableControls').val(JSON.stringify(checkableValues));
+        }
+
+        // add hidden control for additional values given
+        // Will be decoded and assigned to the $_POST var in PHP.
+        if (!$j.isEmptyObject(qcubed.additionalPostVars)) {
+            var input = $j("<input>")
                 .attr("type", "hidden")
-                .attr("name", "Qform__AdditionalPostVars").val($j.param(qcubed.additionalPostVars));
-            $objForm.append($(input));
+                .attr("name", "Qform__AdditionalPostVars").val(JSON.stringify(qcubed.additionalPostVars));
+            $objForm.append(input);
         }
 
         // have $j trigger the submit event (so it can catch all submit events)
@@ -149,7 +159,8 @@ qcubed = {
      * additional post variables. Multiple sets of the same value will overwrite previous value.
      *
      * @param {string} name Name to post. Should probably be the control id, but can be anything.
-     * @param {mixed} val  Any value you want to send to PHP. Can be a string, array or object.
+     * @param {mixed} val  Any value you want to send to PHP. Can be a string, array or simple object. Can also contain null
+     * values and these will become nulls in PHP.
      */
     setAdditionalPostVar: function (name, val) {
         qcubed.additionalPostVars[name] = val;
@@ -158,7 +169,7 @@ qcubed = {
      * This function resolves the state of checkable controls into postable values.
      *
      * Checkable controls (checkboxes and radio buttons) can be problematic. We have the following issues to work around:
-     * - On a submit, only the values of the checeked items are submitted. Non-checked items are not submitted.
+     * - On a submit, only the values of the checked items are submitted. Non-checked items are not submitted.
      * - QCubed may have checkboxes that are part of the form object, but not visible on the html page. In particular,
      *   this can happen when a grid is creating objects at render time, and then scrolls or pages so those objects
      *   are no longer "visible".
@@ -248,7 +259,7 @@ qcubed = {
      * @param {string} strWaitIconControlId Not used, probably legacy code.
      * @return {object} Post Data
      */
-    getPostData: function(strForm, strControl, strEvent, mixParameter, strWaitIconControlId) {
+    getAjaxData: function(strForm, strControl, strEvent, mixParameter, strWaitIconControlId) {
         var $form = $j('#' + strForm),
             $formElements = $form.find('input,select,textarea'),
             checkables = [],
@@ -316,15 +327,20 @@ qcubed = {
         });
 
         // Update most of the Qform__ parameters explicitly here. Others, like the state and form id will have been handled above.
-        postData.Qform__FormParameter = $j.param({obj: mixParameter}); // decoded in PHP
+        if (mixParameter !== undefined) {
+            postData.Qform__FormParameter = JSON.stringify(mixParameter);
+        }
         postData.Qform__FormControl = strControl;
         postData.Qform__FormEvent = strEvent;
         postData.Qform__FormCallType = "Ajax";
-        postData.Qform__FormUpdates = qcubed.controlModifications;
+
+        if (!$j.isEmptyObject(qcubed.controlModifications)) {
+            postData.Qform__FormUpdates = JSON.stringify(qcubed.controlModifications);
+        }
         postData.Qform__FormCheckableControls = qcubed._checkableControlValues(strForm, checkables);
 
-        if (qcubed.additionalPostVars && qcubed.additionalPostVars.length) {
-            $j.extend(postData, qcubed.additionalPostVars);
+        if (!$j.isEmptyObject(qcubed.additionalPostVars)) {
+            postData.Qform__AdditionalPostVars = JSON.stringify(qcubed.additionalPostVars);
             qcubed.additionalPostVars = {};
         }
 
@@ -369,7 +385,7 @@ qcubed = {
             qFormParams: qFormParams,
             fnInit: function(o) {
                 // Get the data at the last possible instant in case the formstate changes between ajax calls
-                o.data = qcubed.getPostData(
+                o.data = qcubed.getAjaxData(
                     o.qFormParams.form,
                     o.qFormParams.control,
                     o.qFormParams.event,

--- a/assets/php/tests/ui_postvars.php
+++ b/assets/php/tests/ui_postvars.php
@@ -1,5 +1,6 @@
 <?php
 require_once('../qcubed.inc.php');
+QApplication::$EncodingType = 'ISO-8859-1';
 
 /**
  * Class MyControl
@@ -39,6 +40,7 @@ class MyControl extends QControl {
 
 class ParamsForm extends QForm {
 	protected $txtText;
+	protected $txt2;
 	protected $pnlTest;
 	protected $lstCheckables;
 
@@ -47,10 +49,13 @@ class ParamsForm extends QForm {
 
 	protected function Form_Create() {
 		$this->txtText = new MyControl($this);
-		$this->txtText->Name = "Text";
+		$this->txtText->Name = "Special Vals";
+
+		$this->txt2 = new QTextBox($this);
+		$this->txt2->Name = "Regular Val";
 
 		$this->pnlTest = new QPanel($this);
-		$this->pnlTest->HtmlEntities = true;
+		//$this->pnlTest->HtmlEntities = true;
 		$this->pnlTest->Name = 'Result';
 
 		$this->lstCheckables = new QCheckBoxList($this);
@@ -84,9 +89,10 @@ class ParamsForm extends QForm {
 		$strResult .= "\n" . var_export($checkables, true);
 		$checkables = $this->lstCheckables->SelectedNames;
 		$strResult .= "\n" . var_export($checkables, true);
+		$strResult .= "\n" . 'Ordinals: ' . ord($this->txtText->Name) . ',' . ord($strResult);
+		$strResult .= "\n" . 'Regular: ' . $this->txt2->Text;
 		
 		$this->pnlTest->Text = $strResult;
 	}
 }
-QApplication::$EncodingType = 'ISO-8859-1';
 ParamsForm::Run('ParamsForm');

--- a/assets/php/tests/ui_postvars.php
+++ b/assets/php/tests/ui_postvars.php
@@ -1,0 +1,92 @@
+<?php
+require_once('../qcubed.inc.php');
+
+/**
+ * Class MyControl
+ * A text box to test the setAdditionalPostVar function's abilities, including ability to pass a null value.
+ */
+class MyControl extends QControl {
+	public $txt;
+	public $nullVal;
+
+	public function GetControlHtml() {
+		return $this->RenderTag('input');
+	}
+	public function ParsePostData() {
+		if (isset($_POST[$this->ControlId . '_extra'])) {
+			$this->txt = $_POST[$this->ControlId . '_extra']['txt'];
+			$this->nullVal = $_POST[$this->ControlId . '_extra']['nullVal'];
+		}
+	}
+
+	public function Validate() {
+		return true;
+	}
+
+	public function GetEndScript()
+	{
+		$strId = $this->ControlId;
+
+		$strJs = parent::GetEndScript();
+		$strJs .= ';';
+		$strJs .= "\$j('#{$strId}').change(function(event) {
+			qcubed.setAdditionalPostVar('{$strId}_extra', {txt: \$j(this).val(), 'nullVal': null});
+			qcubed.recordControlModification('{$strId}', 'Name', \$j(this).val());
+			})";
+		return $strJs;
+	}
+}
+
+class ParamsForm extends QForm {
+	protected $txtText;
+	protected $pnlTest;
+	protected $lstCheckables;
+
+	protected $btnSubmit;
+	protected $btnAjax;
+
+	protected function Form_Create() {
+		$this->txtText = new MyControl($this);
+		$this->txtText->Name = "Text";
+
+		$this->pnlTest = new QPanel($this);
+		$this->pnlTest->HtmlEntities = true;
+		$this->pnlTest->Name = 'Result';
+
+		$this->lstCheckables = new QCheckBoxList($this);
+		$this->lstCheckables->AddItem('é - accented', 'é');
+		$this->lstCheckables->AddItem('ü - umlat', 'ü');
+		$this->lstCheckables->AddItem('î - circuflexed', 'î');
+		$this->lstCheckables->AddItem('ß - Eszett', 'ß');
+
+		$strId = $this->txtText->ControlId;
+		$strJs = "{txt: \$j('#{$strId}').val(), nullVal:null}";
+
+		$this->btnSubmit = new QButton($this);
+		$this->btnSubmit->Text = "Server Submit";
+		$this->btnSubmit->AddAction(new QClickEvent(), new QServerAction('submit_click', null, $strJs));
+
+		$this->btnAjax = new QButton($this);
+		$this->btnAjax->Text = "Ajax Submit";
+		$this->btnAjax->AddAction(new QClickEvent(), new QAjaxAction('submit_click', null, null, $strJs));
+	}
+
+	protected function submit_click($strFormId, $strControlId, $mixParam) {
+		// test setAdditionalPostParam
+		$strResult = $this->txtText->txt;
+		$strResult .= ($this->txtText->nullVal === null ? ' and is null' : ' and is not null');
+
+		// test parameters
+		$strResult .= "\n" . var_export($mixParam, true);
+
+		// test checkables
+		$checkables = $this->lstCheckables->SelectedValues;
+		$strResult .= "\n" . var_export($checkables, true);
+		$checkables = $this->lstCheckables->SelectedNames;
+		$strResult .= "\n" . var_export($checkables, true);
+		
+		$this->pnlTest->Text = $strResult;
+	}
+}
+QApplication::$EncodingType = 'ISO-8859-1';
+ParamsForm::Run('ParamsForm');

--- a/assets/php/tests/ui_postvars.tpl.php
+++ b/assets/php/tests/ui_postvars.tpl.php
@@ -1,0 +1,16 @@
+<?php require(__PROJECT__ . '/includes/configuration/header.inc.php'); ?>
+<?php $this->RenderBegin(); ?>
+<p>This is a stress test for the various ways that data can be retrived from client and delivered to the server. Put text
+in the field and press the submit button. The results of the various attempts will display. They should all show
+the same text as in the field, and a null value. Try international characters in particular. The page also does not
+use UTF-8 encoding to make sure we can decode into any encoding.</p>
+	<?php $this->txtText->RenderWithName(); ?>
+<?php $this->pnlTest->RenderWithName(); ?>
+<?php $this->lstCheckables->Render(); ?>
+<div>
+	<?php $this->btnSubmit->Render(); ?>
+	<?php $this->btnAjax->Render(); ?>
+
+</div>
+<?php $this->RenderEnd(); ?>
+<?php require(__PROJECT__ . '/includes/configuration/footer.inc.php'); ?>

--- a/assets/php/tests/ui_postvars.tpl.php
+++ b/assets/php/tests/ui_postvars.tpl.php
@@ -1,10 +1,12 @@
 <?php require(__PROJECT__ . '/includes/configuration/header.inc.php'); ?>
 <?php $this->RenderBegin(); ?>
-<p>This is a stress test for the various ways that data can be retrived from client and delivered to the server. Put text
-in the field and press the submit button. The results of the various attempts will display. They should all show
+<p>This is a stress test for the various ways that data can be retrieved from client and delivered to the server. Put text
+in the field and press the submit button. Try international characters in particular.
+The results of the various attempts will display. They should all show
 the same text as in the field, and a null value. Try international characters in particular. The page also does not
 use UTF-8 encoding to make sure we can decode into any encoding.</p>
-	<?php $this->txtText->RenderWithName(); ?>
+<?php $this->txtText->RenderWithName(); ?>
+<?php $this->txt2->RenderWithName(); ?>
 <?php $this->pnlTest->RenderWithName(); ?>
 <?php $this->lstCheckables->Render(); ?>
 <div>

--- a/includes/base_controls/QControlBase.class.php
+++ b/includes/base_controls/QControlBase.class.php
@@ -1593,12 +1593,13 @@
 			}
 
 			if ($this->strInstructions){
-				$strInstructions = '<br/><span class="instructions">' . $this->strInstructions . '</span>';
+				$strInstructions = '<br/>' .
+				QHtml::RenderTag('span', ['class'=>"instructions"], QHtml::RenderString($this->strInstructions));
 			}else{
 				$strInstructions = '';
 			}
-			
-			$strToReturn = sprintf('<div class="%s"><label>%s</label>%s</div>', $strLabelClass, $this->strName, $strInstructions);
+			$strLabel = QHtml::RenderTag('label', null, QHtml::RenderString($this->strName));
+			$strToReturn = QHtml::RenderTag('div', ['class'=>$strLabelClass], $strLabel . $strInstructions);
 
 			// Render the Right side
 			$strMessage = '';

--- a/includes/base_controls/QFormBase.class.php
+++ b/includes/base_controls/QFormBase.class.php
@@ -389,7 +389,7 @@
 					self::InvalidFormState();
 				}
 			}
-
+			
 			if ($objClass) {
 				// Globalize
 				global $_FORM;
@@ -400,6 +400,15 @@
 
 				if ($objClass->strCallType == QCallType::Ajax) {
 					QApplication::$RequestMode = QRequestMode::Ajax;
+				}
+
+				// Cleanup ajax post data if the encoding does not match, since ajax data is always utf-8
+				if ($objClass->strCallType == QCallType::Ajax && QApplication::$EncodingType != 'UTF-8') {
+					foreach ($_POST as $key=>$val) {
+						if (substr($key, 0, 6) != 'Qform_') {
+							$_POST[$key] = iconv('UTF-8', QApplication::$EncodingType, $val);
+						}
+					}
 				}
 
 				if (!empty($_POST['Qform__FormParameter'])) {
@@ -460,11 +469,6 @@
 					$objClass->checkableControlValues = [];
 				}
 
-				// Iterate through all the controls
-				
-				// TODO: some listener pattern should be used to update only those
-				// controls that needs it
-
 				// This is original code. In an effort to minimize changes,
 				// we aren't going to touch the server calls for now
 				if ($objClass->strCallType != QCallType::Ajax) {
@@ -485,6 +489,7 @@
 				}
 				else {
 					// Ajax post. Only send data to controls specified in the post to save time.
+
 					$previouslyFoundArray = array();
 					$controls = $_POST;
 					$controls = array_merge($controls, $objClass->checkableControlValues);
@@ -627,8 +632,13 @@
 		 * @return mixed|string
 		 */
 		protected static function UnpackPostVar($val) {
+			if (QApplication::$EncodingType != 'UTF-8' && QApplication::$RequestMode != QRequestMode::Ajax) {
+				// json_decode only accepts utf-8 encoded text. Ajax calls are already UTF-8 encoded.
+				$val = iconv(QApplication::$EncodingType, 'UTF-8', $val);
+			}
 			$val = json_decode($val, true);
 			if (QApplication::$EncodingType != 'UTF-8') {
+				// Must convert back from utf-8 to whatever our application encoding is
 				if (is_string($val)) {
 					$val = iconv('UTF-8', QApplication::$EncodingType, $val);
 				}
@@ -688,7 +698,7 @@
 
 				// Output it and update render state
 				if (QApplication::$EncodingType && QApplication::$EncodingType != 'UTF-8') {
-					$strJSON = mb_convert_encoding($strJSON, 'UTF-8', QApplication::$EncodingType); // json must be UTF-8 encoded
+					$strJSON = iconv(QApplication::$EncodingType, 'UTF-8', $strJSON); // json must be UTF-8 encoded
 				}
 				print ($strJSON);
 			} else {

--- a/includes/base_controls/QImageBase.class.php
+++ b/includes/base_controls/QImageBase.class.php
@@ -241,7 +241,8 @@
 			// Output the Image (if path isn't specified, output to buffer.  Otherwise, output to disk)
 			if (!$strPath) {
 				// Output to Output Stream
-				QApplication::$CacheControl = 'cache';
+				QApplication::$ProcessOutput = false;
+				header('Cache-Control: cache');
 				header('Expires: Wed, 20 Mar 2019 05:00:00 GMT');
 				header('Pragma: cache');
 
@@ -333,7 +334,8 @@
 				else
 					$objFinalImage->writeImage($strPath);
 
-				QApplication::$CacheControl = 'cache';
+				QApplication::$ProcessOutput = false;
+				header('Cache-Control: cache');
 				header('Expires: Wed, 20 Mar 2019 05:00:00 GMT');
 				header('Pragma: cache');
 

--- a/includes/base_controls/QImageControlBase.class.php
+++ b/includes/base_controls/QImageControlBase.class.php
@@ -270,7 +270,8 @@
 
 		protected function SetupContentType() {
 			// TODO: Update Cache Parameters
-			QApplication::$CacheControl = 'cache';
+			QApplication::$ProcessOutput = false;
+			header('Cache-Control: cache');
 			header('Expires: Wed, 20 Mar 2019 05:00:00 GMT');
 			header('Pragma: cache');
 

--- a/includes/base_controls/QImageLabelBase.class.php
+++ b/includes/base_controls/QImageLabelBase.class.php
@@ -302,7 +302,8 @@
 			// Output the Image (if path isn't specified, output to buffer.  Otherwise, output to disk)
 			if (!$strPath) {
 				// TODO: Update Cache Parameters
-				QApplication::$CacheControl = 'cache';
+				QApplication::$ProcessOutput = false;
+				header('Cache-Control: cache');
 				header('Expires: Wed, 20 Mar 2019 05:00:00 GMT');
 				header('Pragma: cache');
 

--- a/includes/framework/QApplicationBase.class.php
+++ b/includes/framework/QApplicationBase.class.php
@@ -1069,6 +1069,8 @@
 				} else {
 					// Update Cache-Control setting
 					header('Cache-Control: ' . QApplication::$CacheControl);
+					// make sure server does not override the character encoding value
+					header(sprintf('Content-Type: text/html; charset=%s', strtolower(QApplication::$EncodingType)));
 
 					/*
 					 * Normally, FormBase->RenderEnd will render the javascripts. In the unusual case

--- a/includes/framework/QApplicationBase.class.php
+++ b/includes/framework/QApplicationBase.class.php
@@ -78,6 +78,9 @@
 		 * can be set/modified by QFormBase::EvaluateTemplate accordingly to
 		 * prevent OutputPage from executing.
 		 *
+		 * Also set this to false if you are outputting custom headers, especially
+		 * if you send your own "Content-Type" header.
+		 *
 		 * @var boolean ProcessOutput
 		 */
 		public static $ProcessOutput = true;
@@ -142,6 +145,14 @@
 		 * @var string EncodingType
 		 */
 		public static $EncodingType = "UTF-8";
+
+		/**
+		 * The content type to output.
+		 *
+		 * @var string ContentType
+		 */
+		public static $ContentType = "text/html";
+
 
 		/**
 		 * An array of Database objects, as initialized by QApplication::InitializeDatabaseConnections()
@@ -1069,8 +1080,9 @@
 				} else {
 					// Update Cache-Control setting
 					header('Cache-Control: ' . QApplication::$CacheControl);
-					// make sure server does not override the character encoding value
-					header(sprintf('Content-Type: text/html; charset=%s', strtolower(QApplication::$EncodingType)));
+					// make sure the server does not override the character encoding value by explicitly sending it out as a header.
+					// some servers will use an internal default if not specified in the header, and that will override the "encoding" value sent in the text.
+					header(sprintf('Content-Type: %s; charset=%s', strtolower(QApplication::$ContentType), strtolower(QApplication::$EncodingType)));
 
 					/*
 					 * Normally, FormBase->RenderEnd will render the javascripts. In the unusual case

--- a/includes/framework/QRssFeed.class.php
+++ b/includes/framework/QRssFeed.class.php
@@ -72,7 +72,8 @@
 
 		public function Run() {
 			ob_clean();
-			header('Content-type: text/xml');
+			QApplication::$ContentType = 'text/xml';
+
 			if (QApplication::$EncodingType)
 				printf("<?xml version=\"1.0\" encoding=\"%s\" ?>\r\n", QApplication::$EncodingType);
 			else

--- a/includes/framework/QSoapService.class.php
+++ b/includes/framework/QSoapService.class.php
@@ -316,12 +316,12 @@
 				if (array_key_exists('QUERY_STRING', $_SERVER))
 					switch (strtolower($_SERVER['QUERY_STRING'])) {
 						case 'disco':
-							header('Content-Type: text/xml');
+							QApplication::$ContentType = 'text/xml';
 							_p('<?xml version="1.0" encoding="' . QApplication::$EncodingType . '"?>', false);
 							_p($objDiscoCache->GetData(), false);
 							return;
 						case 'wsdl':
-							header('Content-Type: text/xml');
+							QApplication::$ContentType = 'text/xml';
 							_p('<?xml version="1.0" encoding="' . QApplication::$EncodingType . '"?>', false);
 							_p($objWsdlCache->GetData(), false);
 							return;


### PR DESCRIPTION
Fixing a number of problems with character encoding that is not UTF-8. I think I have it working so that all variables are unpacked into the same encoding as QApplication::$EncodingType. Tricky stuff.

I would like some people to verify this before committing it, so consider this a work in progress.

In particular, please open the file vendor/qcubed/framework/assets/php/tests/ui-postvars.php in a browser and try it out. Someone please try it in IE. Also, try changing the encoding type at the top of the file to something like cyrillic and test again.

I am concerned in particular about the ability of JSON.stringify to encode non- utf-8 strings, and then have those strings get past through the server submit and ajax submit processes. Some help testing this would be appreciated.