### PR TITLE
bugfix-VirtualAttributeClauses

### DIFF
--- a/assets/php/examples/mysql_innodb.sql
+++ b/assets/php/examples/mysql_innodb.sql
@@ -34,8 +34,8 @@ CREATE TABLE project (
     description TEXT,
     start_date DATE,
     end_date DATE,
-    budget DECIMAL,
-    spent DECIMAL,
+    budget DECIMAL(12,2),
+    spent DECIMAL(12,2),
     CONSTRAINT PK_project PRIMARY KEY (id),
     KEY IDX_project_1(project_status_type_id),
     KEY IDX_project_2(manager_person_id)

--- a/assets/php/examples/pgsql.sql
+++ b/assets/php/examples/pgsql.sql
@@ -48,8 +48,8 @@ CREATE TABLE project (
     description TEXT,
     start_date DATE,
     end_date DATE,
-    budget DECIMAL,
-    spent DECIMAL,
+    budget DECIMAL(12,2),
+    spent DECIMAL(12,2),
     CONSTRAINT PK_project PRIMARY KEY (id)
 );
 CREATE INDEX IDX_project_1 ON project (project_status_type_id);

--- a/assets/php/examples/qcubed_query/qqselect.php
+++ b/assets/php/examples/qcubed_query/qqselect.php
@@ -4,17 +4,23 @@
 <div id="instructions">
 	<h1>Picking database columns for QQuery</h1>
 	
-	<p>By default <strong>QQuery</strong> selects all the columns from the table and thus populates all the properties of
+	<p>Most of the time, <strong>QQuery</strong> selects all the columns from the table and thus populates all the properties of
 	the resulting objects.
 	Normally, this is the right thing to do - the most expensive part of a typical query is hitting the database and
-	performing the query;
-	once the query is performed, fetching as much data as possible is the most efficient behaviour.</p>
+	performing the query;</p>
 	
-	<p>However, when some tables have a large amount of columns, or some <em>LOB</em> columns, this may become expensive,
+	<p>However, when some tables have a large number of columns, or some columns that contain large objects (BLOB, TEXT, etc.), this may become expensive,
 	both in terms of the traffic generated between application and database, and in terms of the memory footprint of the
 	application.</p>
+
+	<p>Also, more and more databases are preventing you from creating SQL queries that might produce ambiguous results when
+		using aggregate clauses. For example, if you create a query that groups employees by last name, and counts how many
+		employees have each last name, but then also tries to select a first name, if there are mulitple employees with the same
+		last name, the database will be confused and won't know which first name to show. Most databases will error in this
+		situation. However, it would be perfectly fine to select a last name, because each group has the same last name.
+		You need a way to specify particular database fields to select.</p>
 	
-	<p><strong>QQ::Select</strong> solves this problem by allowing to pick only the desired subset of columns to fetch from
+	<p><strong>QQ::Select</strong> solves this problem by allowing you to pick particular columns to fetch from
 	the database.</p>
 	
 	<p>QQ::Select can be passed as a clause to any query method.

--- a/includes/base_controls/QSimpleTableColumn.class.php
+++ b/includes/base_controls/QSimpleTableColumn.class.php
@@ -984,6 +984,10 @@
 			if ($strAttribute) {
 				$this->strAttribute = $strAttribute;
 			}
+
+			$this->OrderByClause = QQ::OrderBy(QQ::Virtual($strAttribute));
+			$this->ReverseOrderByClause = QQ::OrderBy(QQ::Virtual($strAttribute), false);
+
 		}
 		
 		public function FetchCellObject($item) {

--- a/includes/codegen/templates/db_orm/class_gen/_main.tpl.php
+++ b/includes/codegen/templates/db_orm/class_gen/_main.tpl.php
@@ -92,19 +92,7 @@
 
 		<?php include("property_set.tpl.php"); ?>
 
-
-		/**
-		 * Lookup a VirtualAttribute value (if applicable).  Returns NULL if none found.
-		 * @param string $strName
-		 * @return string
-		 */
-		public function GetVirtualAttribute($strName) {
-			if (array_key_exists($strName, $this->__strVirtualAttributeArray))
-				return $this->__strVirtualAttributeArray[$strName];
-			return null;
-		}
-
-
+		<?php include("virtual_attribute.tpl.php"); ?>
 
 		<?php include("associated_objects_methods.tpl.php"); ?>
 

--- a/includes/codegen/templates/db_orm/class_gen/virtual_attribute.tpl.php
+++ b/includes/codegen/templates/db_orm/class_gen/virtual_attribute.tpl.php
@@ -1,0 +1,26 @@
+
+		/**
+		 * Lookup a VirtualAttribute value (if applicable).  Returns NULL if none found.
+		 * @param string $strName
+		 * @return string|null
+		 */
+		public function GetVirtualAttribute($strName) {
+			$strName = QQ::GetVirtualAlias($strName);
+			if (isset($this->__strVirtualAttributeArray[$strName])) {
+				return $this->__strVirtualAttributeArray[$strName];
+			}
+			return null;
+		}
+
+		/**
+		 * Returns true if a virtual attribute exists. Useful for telling that the attribute exists, but is null.
+		 * @param string $strName
+		 * @return boolean
+		 */
+		public function HasVirtualAttribute($strName) {
+			$strName = QQ::GetVirtualAlias($strName);
+			if (array_key_exists($strName, $this->__strVirtualAttributeArray)) {
+				return true;
+			}
+			return false;
+		}

--- a/includes/database/QPostgreSqlDatabase.class.php
+++ b/includes/database/QPostgreSqlDatabase.class.php
@@ -36,7 +36,7 @@
 
 		protected $objPgSql;
 		protected $objMostRecentResult;
-		//protected $blnOnlyFullGroupBy = true;
+		protected $blnOnlyFullGroupBy = true;
 
 		public function SqlVariable($mixData, $blnIncludeEquality = false, $blnReverseEquality = false) {
 			// Are we SqlVariabling a BOOLEAN value?

--- a/includes/database/QPostgreSqlPdoDatabase.class.php
+++ b/includes/database/QPostgreSqlPdoDatabase.class.php
@@ -7,8 +7,10 @@
 class QPostgreSqlPdoDatabase extends QPdoDatabase {
 		const Adapter = 'PostgreSQL PDO Database Adapter';
 		const PDO_PGSQL_DSN_IDENTIFIER = 'pgsql';
+		protected $blnOnlyFullGroupBy = true;
 
-		public function InsertOrUpdate($strTable, $mixColumnsAndValuesArray, $strPKNames = null) {
+
+	public function InsertOrUpdate($strTable, $mixColumnsAndValuesArray, $strPKNames = null) {
 			$strEscapedArray = $this->EscapeIdentifiersAndValues($mixColumnsAndValuesArray);
 			$strColumns = array_keys($strEscapedArray);
 			$strUpdateStatement = '';

--- a/includes/framework/QDatabaseBase.class.php
+++ b/includes/framework/QDatabaseBase.class.php
@@ -626,7 +626,7 @@
 				case 'DateFormat':
 					return (is_null($this->objConfigArray[strtolower($strName)])) ? (QDateTime::FormatIso) : ($this->objConfigArray[strtolower($strName)]);
 				case 'OnlyFullGroupBy':
-					return $this->blnOnlyFullGroupBy;
+					return (!isset($this->objConfigArray[strtolower($strName)])) ? $this->blnOnlyFullGroupBy : $this->objConfigArray[strtolower($strName)];
 
 				default:
 					try {

--- a/includes/framework/QModelTrait.trait.php
+++ b/includes/framework/QModelTrait.trait.php
@@ -81,7 +81,9 @@ trait QModelTrait {
 
 		$blnAddAllFieldsToSelect = true;
 		if ($objDatabase->OnlyFullGroupBy) {
-			// see if we have any group by or aggregation clauses, if yes, don't add the fields to select clause
+			// see if we have any group by or aggregation clauses, if yes, don't add all the fields to select clause by default
+			// because these databases post an error instead of just choosing a value to return when a select item could
+			// have multiple values
 			if ($objOptionalClauses instanceof QQClause) {
 				if ($objOptionalClauses instanceof QQAggregationClause || $objOptionalClauses instanceof QQGroupBy) {
 					$blnAddAllFieldsToSelect = false;
@@ -95,9 +97,12 @@ trait QModelTrait {
 				}
 			}
 		}
-		if ($blnAddAllFieldsToSelect) {
-			static::BaseNode()->PutSelectFields($objQueryBuilder, null, QQuery::extractSelectClause($objOptionalClauses));
+
+		$objSelectClauses = QQuery::ExtractSelectClause($objOptionalClauses);
+		if ($objSelectClauses || $blnAddAllFieldsToSelect) {
+			static::BaseNode()->PutSelectFields($objQueryBuilder, null, $objSelectClauses);
 		}
+
 		$objQueryBuilder->AddFromItem($strTableName);
 
 		// Set "CountOnly" option (if applicable)

--- a/install/project/includes/configuration/configuration.inc.sample.php
+++ b/install/project/includes/configuration/configuration.inc.sample.php
@@ -246,9 +246,14 @@ if (!defined('SERVER_INSTANCE')) {
 	 *		NOTE: Profiling should only be enabled when you are actively wanting to profile a
 	 *		specific PHP script or scripts.  Because of SIGNIFICANT performance degradation,
 	 *		it should otherwise always be OFF.
-	 * "ScriptPath": you can have CodeGen virtually add additional FKs, even though they are
-	 * 		not defined as a DB constraint in the database, by using a script to define what
-	 * 		those constraints are.  The path of the script can be defined here. - default is blank or none
+	 * "encoding": Only used for MYSQL. Specifies the encoding for traffic between the client and the database.
+	 * "onlyfullgroupby": This controls whether your database can accept ambiguous select fields when doing
+	 *   aggregate clauses (see the QQ::Select example for more detail). You only need to set this if your
+	 *   database adapter doesn't have the right value. In some databases, this is configurable.
+	 *   In particular, MYSQL 5.7.5 changed the default of this value to true.  Our adapter has this set to false.
+	 *   You can see what your setting is by executing 'SELECT @@sql_mode' in mysql; If ONLY_FULL_GROUP_BY appears
+	 *   in the list, you should set this configuration value to true.
+	 *
 	 * Note: any option not used or set to blank will result in using the default value for that option
 	 */
 
@@ -262,7 +267,9 @@ if (!defined('SERVER_INSTANCE')) {
 		'password' => '{db1_password}',
 		'caching' => false,
 		'profiling' => false,
-		'encoding' => 'utf8')));
+		'encoding' => 'utf8',
+		'dateformat' => null,
+		'onlyfullgroupby' => defined by db adapter)));
 	-->*/
 
 	// Additional Database Connection Strings can be defined here (e.g. for connection #2, #3, #4, #5, etc.)


### PR DESCRIPTION
Consolidating the conversion of virtual aliases so they are consistent wherever they are used.

Changes to:
- Make aggregation clauses the same as virtual attributes in every way
- Use virtual attributes in order by clauses as aliases
- Add string functions to math and func nodes
- Kill uneeded terminating php tag
- Unit test
- Fixing test problem with aggregate clauses, that revealed additional problems around the issue of OnlyFullGroupBy databases.

Changed PostgresSql to be OnlyFullGroupBy by default.

Added a database adapter option so you can override the default when you set up the adapter.
Fixing error related to problem with precision in database declaration. MYSQL standard says specifying DECIMAL with no precision should result in zero decimal places. POSTGRESQL ignores the standard, and we had the unintended consequence of clobbering some of the test data in MYSQL. This makes both sides equal, and fixes the test to check for a decimal place.