### PR TITLE
bugfix-ControlTemplateLocation

### DIFF
--- a/includes/base_controls/QControlBase.class.php
+++ b/includes/base_controls/QControlBase.class.php
@@ -405,7 +405,7 @@
 				ob_start('__QForm_EvaluateTemplate_ObHandler');
 
 				// If no path is specified, use the path of the child control's file.
-				if (strpos($strTemplate, '/') === false) {
+				if (strpos($strTemplate, DIRECTORY_SEPARATOR) === false) {
 					$reflector = new ReflectionClass(get_class($this));
 					$strDir = dirname($reflector->getFileName());
 					$strTemplate = $strDir . DIRECTORY_SEPARATOR . $strTemplate;

--- a/includes/base_controls/QControlBase.class.php
+++ b/includes/base_controls/QControlBase.class.php
@@ -403,6 +403,14 @@
 
 				// Evaluate the new template
 				ob_start('__QForm_EvaluateTemplate_ObHandler');
+
+				// If no path is specified, use the path of the child control's file.
+				if (strpos($strTemplate, '/') === false) {
+					$reflector = new ReflectionClass(get_class($this));
+					$strDir = dirname($reflector->getFileName());
+					$strTemplate = $strDir . DIRECTORY_SEPARATOR . $strTemplate;
+				}
+
 				require($strTemplate);
 				$strTemplateEvaluated = ob_get_contents();
 				ob_end_clean();


### PR DESCRIPTION
Control templates are searched for in the same location as the form include file that they are included in.

This fix places the control template in the same directory as the control definition file if no path is specified.