### PR TITLE
feature-AsyncAjax

### DIFF
--- a/assets/js/qcubed.js
+++ b/assets/js/qcubed.js
@@ -22,9 +22,11 @@ $j.fn.extend({
  * A new Ajax request won't be started until the previous queued
  * request has finished.
  * @param {object} o Options.
+ * @param {boolean} blnAsync true to launch right away.
  */
-$j.ajaxQueue = function(o) {
-    if (typeof $j.ajaxq === "undefined") {
+$j.ajaxQueue = function(o, blnAsync) {
+    if (typeof $j.ajaxq === "undefined" || blnAsync) {
+        if (o.fnInit) o.fnInit(o);
         $j.ajax(o);
     } else {
         // see http://code.google.com/p/jquery-ajaxq/ for details
@@ -361,10 +363,11 @@ qcubed = {
      * @param {string} strEvent
      * @param {null|string|Object|Array} mixParameter
      * @param {string} strWaitIconControlId The id of the control's spinner.
+     * @param {boolean} blnAsync Whether to queue the ajax requests and processes serially (default), or do them async
      * @return {void}
      * @todo There is an eval() in here. We need to find a way around that.
      */
-    postAjax: function(strForm, strControl, strEvent, mixParameter, strWaitIconControlId) {
+    postAjax: function(strForm, strControl, strEvent, mixParameter, strWaitIconControlId, blnAsync) {
         var objForm = $j('#' + strForm),
             strFormAction = objForm.attr("action"),
             qFormParams = {};
@@ -448,7 +451,7 @@ qcubed = {
                     qcubed.processDeferredAjaxResponse(json);
                 }
             }
-        });
+        }, blnAsync);
 
     },
 

--- a/assets/js/qcubed.js
+++ b/assets/js/qcubed.js
@@ -363,7 +363,8 @@ qcubed = {
      * @param {string} strEvent
      * @param {null|string|Object|Array} mixParameter
      * @param {string} strWaitIconControlId The id of the control's spinner.
-     * @param {boolean} blnAsync Whether to queue the ajax requests and processes serially (default), or do them async
+     * @param {boolean} blnAsync Whether to queue the ajax requests and processes serially (default), or do them async.
+     *                  See QAjaxAction comments for more info
      * @return {void}
      * @todo There is an eval() in here. We need to find a way around that.
      */

--- a/includes/base_controls/_actions.inc.php
+++ b/includes/base_controls/_actions.inc.php
@@ -278,6 +278,8 @@
 		protected $strMethodName;
 		/** @var QWaitIcon Wait Icon to be used for this particular action */
 		protected $objWaitIconControl;
+
+		protected $blnAsync = false;
 		/**
 		 * @var mixed what kind of validation over-ride is to be implemented
 		 *              (See the QCausesValidation class and QFormBase class to understand in greater depth)
@@ -297,12 +299,13 @@
 		 *                                                      client-side when the action occurs!
 		 */
 		public function __construct($strMethodName = null, $objWaitIconControl = 'default',
-		                            $mixCausesValidationOverride = null, $strJsReturnParam = "") {
+		                            $mixCausesValidationOverride = null, $strJsReturnParam = "", $blnAsync = false) {
 			$this->strId = null;
 			$this->strMethodName = $strMethodName;
 			$this->objWaitIconControl = $objWaitIconControl;
 			$this->mixCausesValidationOverride = $mixCausesValidationOverride;
 			$this->strJsReturnParam = $strJsReturnParam;
+			$this->blnAsync = $blnAsync;
 		}
 
 		public function __clone() {
@@ -386,8 +389,9 @@
 				}
 			}
 
-			return sprintf("qc.pA('%s', '%s', '%s#%s', %s, '%s');",
-				$objControl->Form->FormId, $objControl->ControlId, addslashes(get_class($this->objEvent)), $this->strId, $this->getActionParameter($objControl), $strWaitIconControlId);
+			return sprintf("qc.pA('%s', '%s', '%s#%s', %s, '%s', %s);",
+				$objControl->Form->FormId, $objControl->ControlId, addslashes(get_class($this->objEvent)), $this->strId,
+				$this->getActionParameter($objControl), $strWaitIconControlId, $this->blnAsync ? 'true' : 'false');
 		}
 	}
 
@@ -425,8 +429,8 @@
 		 * @param string   $strJsReturnParam            Override for ActionParameter
 		 */
 		public function __construct(QControl $objControl, $strMethodName, $objWaitIconControl = 'default',
-		                            $mixCausesValidationOverride = null, $strJsReturnParam = "") {
-			parent::__construct($objControl->ControlId . ':' . $strMethodName, $objWaitIconControl, $mixCausesValidationOverride, $strJsReturnParam);
+		                            $mixCausesValidationOverride = null, $strJsReturnParam = "", $blnAsync = false) {
+			parent::__construct($objControl->ControlId . ':' . $strMethodName, $objWaitIconControl, $mixCausesValidationOverride, $strJsReturnParam, $blnAsync);
 		}
 	}
 
@@ -1305,4 +1309,3 @@
 		}
 	}
 
-?>

--- a/includes/base_controls/_actions.inc.php
+++ b/includes/base_controls/_actions.inc.php
@@ -257,8 +257,25 @@
 	}
 
 	/**
-	 * Ajax actions are handled through an asynchronous HTTP request (=AJAX).
-	 * No full-page refresh happens when such an action is executing.
+	 * The QAjaxAction responds to events with ajax calls, which refresh a portion of a web page without reloading
+	 * the entire page. They generally are faster than server requests and give a better user experience.
+	 * 
+	 * The QAjaxAction will associate a callback (strMethodName) with an event as part of an AddAction call. The callback will be 
+	 * a method in the current QForm object. To associate a method that is part of a QControl, or any kind of a callback,
+	 * use a QAjaxControlAction.
+	 * 
+	 * The wait icon is a spinning gif file that can be overlayed on top of the control to show that the control is in
+	 * a "loading" state. TODO: Convert this to a FontAwesome animated icon.
+	 *
+	 * mixCausesValidationOverride allows you to selectively say whether this action causes a validation, and on what subset of controls.
+	 * 
+	 * strJsReturnParam is a javascript string that specifies what the action parameter will be, if you don't want the default.
+	 * 
+	 * blnAsync lets you respond to the event asynchronously. Use care when setting this to true. Normally, qcubed will
+	 * put events in a queue and wait for each event to return a result before executing the next event. Most of the time,
+	 * the user experience is fine with this. However, there are times when events might be firing quickly and you do
+	 * not want to wait. However, your QFormState handler must be able to handle asynchronous events.
+	 * The default QFormStateHandler cannot do this, so you will need to use a different one.
 	 *
 	 * @property-read           $MethodName               Name of the (event-handler) method to be called
 	 *              the event handler - function containing the actual code for the Ajax action
@@ -292,11 +309,14 @@
 		protected $strJsReturnParam;
 
 		/**
+		 * AjaxAction constructor. 
 		 * @param string           $strMethodName               Name of the event handler function to be called
 		 * @param string|QWaitIcon $objWaitIconControl          Wait Icon for the action
 		 * @param null|mixed       $mixCausesValidationOverride what kind of validation over-ride is to be implemented
 		 * @param string           $strJsReturnParam            the line of javascript which would set the 'strParameter' value on the
 		 *                                                      client-side when the action occurs!
+		 * @param boolean  		   $blnAsync            		True to have the events for this action fire asynchronously.
+		 * 														Be careful when setting this to true. See class description.
 		 */
 		public function __construct($strMethodName = null, $objWaitIconControl = 'default',
 		                            $mixCausesValidationOverride = null, $strJsReturnParam = "", $blnAsync = false) {
@@ -416,7 +436,7 @@
 
 	/**
 	 * Ajax control action is identical to Ajax action, except
-	 * the handler for it is defined NOT on the form host, but on a control.
+	 * the handler for it is defined NOT on the form host, but on a QControl.
 	 *
 	 * @package Actions
 	 */
@@ -427,6 +447,7 @@
 		 * @param string   $objWaitIconControl          The wait icon to be implemented
 		 * @param null     $mixCausesValidationOverride Override for CausesValidation (if needed)
 		 * @param string   $strJsReturnParam            Override for ActionParameter
+		 * @param boolean  $blnAsync            		True to have the events for this action fire asynchronously
 		 */
 		public function __construct(QControl $objControl, $strMethodName, $objWaitIconControl = 'default',
 		                            $mixCausesValidationOverride = null, $strJsReturnParam = "", $blnAsync = false) {

--- a/includes/qform_state_handlers/QDbBackedFormStateHandler.class.php
+++ b/includes/qform_state_handlers/QDbBackedFormStateHandler.class.php
@@ -5,12 +5,16 @@
 	 * is saved in its own row in the DB, and only the form state that is needed for loading will
 	 * be accessed (as opposed to with session, ALL the form states are loaded into memory
 	 * every time).
+	 * 
 	 * The downside is that because it doesn't utilize PHP's session management subsystem,
 	 * this class must take care of its own garbage collection/deleting of old/outdated
 	 * formstate files.
-	 * Because the index is randomy generated and MD5-hashed, there is no benefit from
+	 * 
+	 * Because the index is randomly generated and MD5-hashed, there is no benefit from
 	 * encrypting it -- therefore, the QForm encryption preferences are ignored when using
 	 * QFileFormStateHandler.
+	 * 
+	 * This handler can handle asynchronous calls.
 	 */
 	class QDbBackedFormStateHandler extends QBaseClass {
 
@@ -222,5 +226,3 @@
 			return $strSerializedForm;
 		}
 	}
-
-?>

--- a/includes/qform_state_handlers/QFileFormStateHandler.class.php
+++ b/includes/qform_state_handlers/QFileFormStateHandler.class.php
@@ -13,6 +13,8 @@
 	 * Because the index is randomy generated and MD5-hashed, there is no benefit from
 	 * encrypting it -- therefore, the QForm encryption preferences are ignored when using
 	 * QFileFormStateHandler.
+	 *
+	 * This formstate handler is compatible with asynchronous ajax calls.
 	 */
 	class QFileFormStateHandler extends QBaseClass {
 		/**
@@ -114,8 +116,12 @@
 			// Figure Out Session Id (if applicable)
 			$strSessionId = session_id();
 
-			// Calculate a new unique Page Id
-			$strPageId = md5(microtime());
+			if (!empty($_POST['Qform__FormState']) && QApplication::$RequestMode == QRequestMode::Ajax) {
+				$strPageId = $_POST['Qform__FormState'];	// reuse old page id
+			} else {
+				// Calculate a new unique Page Id
+				$strPageId = md5(microtime());
+			}
 
 			// Figure Out FilePath
 			$strFilePath = sprintf('%s/%s%s_%s',
@@ -165,4 +171,3 @@
 				return null;
 		}
 	}
-?>

--- a/includes/qform_state_handlers/QFormStateHandler.class.php
+++ b/includes/qform_state_handlers/QFormStateHandler.class.php
@@ -1,8 +1,22 @@
 <?php
 	/**
-	 * This is the "standard" FormState handler, storing the base64 encoded session data
-	 * (and if requested by QForm, encrypted) as a hidden form variable on the page, itself.
+	 * Class QFormStateHandler
+	 * This is the default FormState handler, storing the base64 encoded session data
+	 * (and if requested by QForm, encrypted) as a hidden form variable on the page, itself. It is meant to be a "quick
+	 * and dirty" handler that works in limited situations.
+	 *
+	 * We recommend that you do NOT use this formstate handler in general. It sends the entire formstate back and forth
+	 * to the client browser on every server and ajax request, which is slow, and could potentially reach limits quickly. It
+	 * encrypts the data, but there are still potential security problems if the data is sensitive.
+	 *
+	 * To change the formstate handler, define the __FORM_STATE_HANDLER__ in your configuration.inc.php file. See that
+	 * file for more detail.
+	 *
+	 * This form state handler is NOT safe to use when making asynchronous AJAX calls. The reason is that since the entire
+	 * formstate is sent to the browser, each ajax call must wait for the return trip to get the new formstate, before
+	 * sending the formstate back to the server on the next ajax call.
 	 */
+
 	class QFormStateHandler extends QBaseClass {
 		public static function Save($strFormState, $blnBackButtonFlag) {
 			// Compress (if available)

--- a/includes/qform_state_handlers/QSessionFormStateHandler.class.php
+++ b/includes/qform_state_handlers/QSessionFormStateHandler.class.php
@@ -10,8 +10,10 @@
 	 * 
 	 * If requested by QForm, the index will be encrypted.
 	 * 
-	 * This incorporates a system of garbage collection that will allow for at most
-	 * 
+	 * This incorporates a system of garbage collection that will allow for at most BackButtonMax
+	 * formstates to be saved in the session.
+	 *
+	 * This handler is compatible with asynchronous ajax calls.
 	 *
 	 */
 	class QSessionFormStateHandler extends QBaseClass {


### PR DESCRIPTION
This adds the ability to send ajax events to the server asynchronously. By default, multiple ajax events are queued, and each one can not fire until the previous one returns a result and the result is processed. The primary reason for this is to allow the formstate to be refreshed.

However, there are times when you don't want to wait:
1. You are using a formstate handler that reuses the same formstate key for ajax events (the db handler does this now.) So, you know the formstate key is not going to change between ajax calls.
2. You are rapidly sending ajax events to give quick user feedback.
