### PR TITLE
bugfix-AssertEquals

### DIFF
--- a/includes/tests/qcubed-unit/BasicOrmTest.php
+++ b/includes/tests/qcubed-unit/BasicOrmTest.php
@@ -38,11 +38,11 @@ class BasicOrmTests extends QUnitTestCaseBase {
 			)
 		);
 				
-		$this->assertEquals(sizeof($items), 1, "Saved the Person object");
+		$this->assertEquals(1, sizeof($items), "Saved the Person object");
 			
 		$objPerson2 = $items[0];
-		$this->assertEquals($objPerson2->FirstName, "Test1", "The first name is correct");
-		$this->assertEquals($objPerson2->LastName,  "Last1", "The last name is correct");
+		$this->assertEquals("Test1", $objPerson2->FirstName, "The first name is correct");
+		$this->assertEquals("Last1", $objPerson2->LastName, "The last name is correct");
 		
 		$objPerson2->Delete();
 
@@ -53,7 +53,7 @@ class BasicOrmTests extends QUnitTestCaseBase {
 			)						  
 		);
 		
-		$this->assertEquals(sizeof($items), 0, "Deleting the Person object");
+		$this->assertEquals(0, sizeof($items), "Deleting the Person object");
 	}
 
 	public function testQueryArray() {
@@ -65,16 +65,16 @@ class BasicOrmTests extends QUnitTestCaseBase {
 			QQ::OrderBy(QQN::Milestone()->Project->Name)
 		);
 		
-		$this->assertEquals(sizeof($objItems), 3);
+		$this->assertEquals(3, sizeof($objItems));
 
-		$this->assertEquals($objItems[0]->Name, "Milestone F");
-		$this->assertEquals($objItems[0]->Project->Name, "Blueman Industrial Site Architecture");
+		$this->assertEquals("Milestone F", $objItems[0]->Name);
+		$this->assertEquals("Blueman Industrial Site Architecture", $objItems[0]->Project->Name);
 
-		$this->assertEquals($objItems[1]->Name, "Milestone D");
-		$this->assertEquals($objItems[1]->Project->Name, "State College HR System");
+		$this->assertEquals("Milestone D", $objItems[1]->Name);
+		$this->assertEquals("State College HR System", $objItems[1]->Project->Name);
 
-		$this->assertEquals($objItems[2]->Name, "Milestone E");
-		$this->assertEquals($objItems[2]->Project->Name, "State College HR System");
+		$this->assertEquals("Milestone E", $objItems[2]->Name);
+		$this->assertEquals("State College HR System", $objItems[2]->Project->Name);
 	}
 	
 	public function testQueryCount() {
@@ -88,7 +88,7 @@ class BasicOrmTests extends QUnitTestCaseBase {
 			QQ::Distinct()
 		);
 		
-		$this->assertEquals($intItemCount, 3);
+		$this->assertEquals(3, $intItemCount);
 
 		$intItemCount2 = Milestone::QueryCount(
 			QQ::GreaterThan(QQN::Milestone()->Project->StartDate, $someDate),
@@ -100,7 +100,7 @@ class BasicOrmTests extends QUnitTestCaseBase {
 			)
 		);
 		
-		$this->assertEquals($intItemCount2, 3);
+		$this->assertEquals(3, $intItemCount2);
 	}
 	
 	public function testOrderByCondition() {
@@ -113,10 +113,10 @@ class BasicOrmTests extends QUnitTestCaseBase {
 				)
 			);
 
-		$this->assertEquals($objItems[0]->FirstName . " " . $objItems[0]->LastName, "Alex Smith");
-		$this->assertEquals($objItems[1]->FirstName . " " . $objItems[1]->LastName, "Jennifer Smith");
-		$this->assertEquals($objItems[2]->FirstName . " " . $objItems[2]->LastName, "Wendy Smith");
-		$this->assertEquals($objItems[3]->FirstName . " " . $objItems[3]->LastName, "Ben Robinson");
+		$this->assertEquals("Alex Smith", $objItems[0]->FirstName . " " . $objItems[0]->LastName);
+		$this->assertEquals("Jennifer Smith", $objItems[1]->FirstName . " " . $objItems[1]->LastName);
+		$this->assertEquals("Wendy Smith", $objItems[2]->FirstName . " " . $objItems[2]->LastName);
+		$this->assertEquals("Ben Robinson", $objItems[3]->FirstName . " " . $objItems[3]->LastName);
 	}
 	
 	public function testGroupBy() {
@@ -129,12 +129,12 @@ class BasicOrmTests extends QUnitTestCaseBase {
 			)
 		);
 		
-		$this->assertEquals(sizeof($objItems), 4, "4 projects found");
+		$this->assertEquals(4, sizeof($objItems), "4 projects found");
 		
-		$this->assertEquals($objItems[0]->GetVirtualAttribute('team_member_count'), 5, "5 team members found for the first project");
-		$this->assertEquals($objItems[1]->GetVirtualAttribute('team_member_count'), 6, "6 team members found for the second project");
-		$this->assertEquals($objItems[2]->GetVirtualAttribute('team_member_count'), 5, "5 team members found for the third project");
-		$this->assertEquals($objItems[3]->GetVirtualAttribute('team_member_count'), 7, "7 team members found for the forth project");
+		$this->assertEquals(5, $objItems[0]->GetVirtualAttribute('team_member_count'), "5 team members found for the first project");
+		$this->assertEquals(6, $objItems[1]->GetVirtualAttribute('team_member_count'), "6 team members found for the second project");
+		$this->assertEquals(5, $objItems[2]->GetVirtualAttribute('team_member_count'), "5 team members found for the third project");
+		$this->assertEquals(7, $objItems[3]->GetVirtualAttribute('team_member_count'), "7 team members found for the forth project");
 	}
 	
 	public function testAssociationTables() {
@@ -152,7 +152,7 @@ class BasicOrmTests extends QUnitTestCaseBase {
 			$arrNamesOnly[] = $item->FirstName . " " . $item->LastName;
 		 }
 		
-		$this->assertEquals($arrNamesOnly, array(
+		$this->assertEquals(array(
 			"Brett Carlisle",
 			"John Doe",
 			"Samantha Jones",
@@ -161,8 +161,9 @@ class BasicOrmTests extends QUnitTestCaseBase {
 			"Ben Robinson",
 			"Alex Smith",
 			"Wendy Smith",
-			"Karen Wolfe")
-		, "List managed persons is correct");
+			"Karen Wolfe"),
+			$arrNamesOnly,
+			"List managed persons is correct");
 		
 		$objPersonArray = Person::QueryArray(
 			QQ::Equal(QQN::Person()->PersonType->PersonTypeId, PersonType::Inactive),
@@ -176,11 +177,12 @@ class BasicOrmTests extends QUnitTestCaseBase {
 			$arrNamesOnly[] = $item->FirstName . " " . $item->LastName;
 		}
 		
-		$this->assertEquals($arrNamesOnly, array(
+		$this->assertEquals(array(
 			"Linda Brady",
 			"John Doe",
 			"Ben Robinson")
-		, "Person-PersonType assn is correct");
+			, $arrNamesOnly
+			, "Person-PersonType assn is correct");
 		
 	}
 	
@@ -188,7 +190,7 @@ class BasicOrmTests extends QUnitTestCaseBase {
 		$targetPerson = Person::QuerySingle(
 			QQ::Equal(QQN::Person()->Id, 1241243));
 		
-		$this->assertEquals($targetPerson, null, "QuerySingle should return null for a not-found record");		
+		$this->assertEquals(null, $targetPerson, "QuerySingle should return null for a not-found record");
 	}
 
 	public function testQuerySelectSubset() {
@@ -201,10 +203,10 @@ class BasicOrmTests extends QUnitTestCaseBase {
 	
 	public function testLoadAll() {
 		$objPersonArray = Person::LoadAll ();
-		$this->assertEquals(count($objPersonArray), 12, "12 people found.");
+		$this->assertEquals(12, count($objPersonArray), "12 people found.");
 		
 		$objTwoKeyArray = TwoKey::LoadAll();
-		$this->assertEquals(count($objTwoKeyArray), 6, "6 TwoKey items found.");
+		$this->assertEquals(6, count($objTwoKeyArray), "6 TwoKey items found.");
 	}
 	
 	public function testQuerySelectSubsetSkipPK() {
@@ -230,11 +232,11 @@ class BasicOrmTests extends QUnitTestCaseBase {
 			);
 		
 		$this->assertTrue(!is_null($objMilestone->Name), "Milestone 1 has a name");
-		$this->assertEquals($objMilestone->Name, "Milestone A", "Milestone 1 has name of Milestone A");
+		$this->assertEquals("Milestone A", $objMilestone->Name, "Milestone 1 has name of Milestone A");
 		$this->assertTrue(!is_null($objMilestone->Project->Name), "Project 1 has a name");
-		$this->assertEquals($objMilestone->Project->Name, "ACME Website Redesign", "Project 1 has name of ACME Website Redesign");
+		$this->assertEquals("ACME Website Redesign", $objMilestone->Project->Name, "Project 1 has name of ACME Website Redesign");
 		$this->assertTrue(!is_null($objMilestone->Project->ManagerPerson->FirstName), "Person 7 has a name");
-		$this->assertEquals($objMilestone->Project->ManagerPerson->FirstName, "Karen", "Person 7 has first name of Karen");
+		$this->assertEquals("Karen", $objMilestone->Project->ManagerPerson->FirstName, "Person 7 has first name of Karen");
 		
 		 $clauses = QQ::Clause(
 			QQ::ExpandAsArray (QQN::Project()->PersonAsTeamMember),
@@ -254,13 +256,14 @@ class BasicOrmTests extends QUnitTestCaseBase {
 			$arrNamesOnly[] = $item->FirstName . " " . $item->LastName;
 		}
 		
-		$this->assertEquals($arrNamesOnly, array(
+		$this->assertEquals(array(
 			"Samantha Jones",
 			"Kendall Public",
 			"Alex Smith",
 			"Wendy Smith",
 			"Karen Wolfe")
-				, "Project Team Member expansion is correct");
+			, $arrNamesOnly
+			, "Project Team Member expansion is correct");
 		
 		// long reach
 		$clauses = QQ::Clause(
@@ -281,14 +284,15 @@ class BasicOrmTests extends QUnitTestCaseBase {
 			$arrNamesOnly[] = $item->FirstName . " " . $item->LastName;
 		}
 		
-		$this->assertEquals($arrNamesOnly, array(
+		$this->assertEquals(array(
 			"Samantha Jones",
 			"Kendall Public",
 			"Alex Smith",
 			"Wendy Smith",
 			"Karen Wolfe"
 			)
-		, "Long reach Milestone to Project Team Member expansion is correct");
+			, $arrNamesOnly
+			, "Long reach Milestone to Project Team Member expansion is correct");
 	}
 
 	/**
@@ -303,7 +307,7 @@ class BasicOrmTests extends QUnitTestCaseBase {
 		$objProject = $objPerson->ProjectAsManager;
 		$objPerson2 = $objProject->ManagerPerson;
 
-		$this->assertEquals($objPerson2->FirstName, 'test');
+		$this->assertEquals('test', $objPerson2->FirstName);
 
 		
 		// Test forward reference looking back
@@ -313,7 +317,7 @@ class BasicOrmTests extends QUnitTestCaseBase {
 		$objPerson = $objProject->ManagerPerson;
 		$objProject2 = $objPerson->ProjectAsManager;
 
-		$this->assertEquals($objProject2->Name, 'test');
+		$this->assertEquals('test', $objProject2->Name);
 
 		// test unique reverse reference
 		$clauses = [QQ::Expand(QQN::Person()->Login)];
@@ -322,7 +326,7 @@ class BasicOrmTests extends QUnitTestCaseBase {
 		$objLogin = $objPerson->Login;
 		$objPerson2 = $objLogin->Person;
 
-		$this->assertEquals($objPerson2->FirstName, 'test');
+		$this->assertEquals('test', $objPerson2->FirstName);
 
 		// test many-to-many expansion
 		$clauses = [QQ::ExpandAsArray(QQN::Project()->PersonAsTeamMember)];
@@ -331,7 +335,7 @@ class BasicOrmTests extends QUnitTestCaseBase {
 		$objPersonArray = $objProject->_PersonAsTeamMemberArray;
 		$objProject2 = $objPersonArray[0]->_ProjectAsTeamMember;
 
-		$this->assertEquals($objProject2->Name, 'test');
+		$this->assertEquals('test', $objProject2->Name);
 
 	}
 	
@@ -347,10 +351,10 @@ class BasicOrmTests extends QUnitTestCaseBase {
 			)
 		);
 		
-		$this->assertEquals(sizeof($objItems), 2, "2 projects found");
+		$this->assertEquals(2, sizeof($objItems), "2 projects found");
 		
-		$this->assertEquals($objItems[0]->Name, "State College HR System", "Project " . $objItems[0]->Name . " found");
-		$this->assertEquals($objItems[0]->GetVirtualAttribute('team_member_count'), 6, "6 team members found for project " . $objItems[0]->Name);	
+		$this->assertEquals("State College HR System", $objItems[0]->Name, "Project " . $objItems[0]->Name . " found");
+		$this->assertEquals(6, $objItems[0]->GetVirtualAttribute('team_member_count'), "6 team members found for project " . $objItems[0]->Name);
 	}
 	
 	public function testEmptyColumns() {
@@ -381,7 +385,7 @@ class BasicOrmTests extends QUnitTestCaseBase {
 			QQ::IsNotNull(QQN::Person()->ProjectAsManager->Id),
 			[QQ::OrderBy(QQN::Person()->ProjectAsManager)]
 		);
-		$this->assertEquals($objPerson->Id, 7, "Manager of first project found.");
+		$this->assertEquals(7, $objPerson->Id, "Manager of first project found.");
 
 	}
 
@@ -393,7 +397,7 @@ class BasicOrmTests extends QUnitTestCaseBase {
 			)
 		);
 
-		$this->assertEquals($objPersonArray[0]->Id, 7, "Found first project with manager");
+		$this->assertEquals(7, $objPersonArray[0]->Id, "Found first project with manager");
 	}
 
 	public function testVirtualAttributeAliases() {
@@ -412,4 +416,4 @@ class BasicOrmTests extends QUnitTestCaseBase {
 		$this->assertEquals(5599.50, $amount2);
 	}
 }
-?>
+

--- a/includes/tests/qcubed-unit/CacheTest.php
+++ b/includes/tests/qcubed-unit/CacheTest.php
@@ -50,24 +50,24 @@ class CacheTests extends QUnitTestCaseBase {
 			self::getTestClauses()
 		);
 				
-		$this->assertEquals(sizeof($arrPeople), 12, "12 Person objects found");
+		$this->assertEquals(12, sizeof($arrPeople), "12 Person objects found");
 		$targetPerson = $this->verifyObjectPropertyHelper($arrPeople, 'LastName', 'Wolfe');
 		
 		$this->helperVerifyKarenWolfe($targetPerson);
 		
 		$objProjectArray = $targetPerson->_ProjectAsManagerArray;
-		$this->assertEquals(sizeof($objProjectArray), 2, "2 projects found");
+		$this->assertEquals(2, sizeof($objProjectArray), "2 projects found");
 		
 		foreach ($objProjectArray as $objProject) {
 			$objMilestoneArray = $objProject->_MilestoneArray;
 			
 			switch ($objProject->Id) {
 				case 1:
-					$this->assertEquals(sizeof($objMilestoneArray), 3, "3 milestones found");
+					$this->assertEquals(3, sizeof($objMilestoneArray), "3 milestones found");
 					break;
 					
 				case 4:
-					$this->assertEquals(sizeof($objMilestoneArray), 4, "4 milestones found");
+					$this->assertEquals(4, sizeof($objMilestoneArray), "4 milestones found");
 					break;
 					
 				default:
@@ -88,7 +88,7 @@ class CacheTests extends QUnitTestCaseBase {
 		);
 
 		// Karen Wolfe should duplicate, since she is managing two projects
-		$this->assertEquals(sizeof($arrPeople), 13, "13 Person objects found");
+		$this->assertEquals(13, sizeof($arrPeople), "13 Person objects found");
 		$targetPerson = $this->verifyObjectPropertyHelper($arrPeople, 'LastName', 'Wolfe');
 
 		$objProjectArray = $targetPerson->_ProjectAsManagerArray;
@@ -101,11 +101,11 @@ class CacheTests extends QUnitTestCaseBase {
 		// since we didn't specify the order, not sure which one we will get, so check for either
 		switch ($objProject->Id) {
 			case 1:
-				$this->assertEquals(sizeof($objMilestoneArray), 3, "3 milestones found");
+				$this->assertEquals(3, sizeof($objMilestoneArray), "3 milestones found");
 				break;
 				
 			case 4:
-				$this->assertEquals(sizeof($objMilestoneArray), 4, "4 milestones found");
+				$this->assertEquals(4, sizeof($objMilestoneArray), "4 milestones found");
 				break;
 				
 			default:
@@ -164,7 +164,7 @@ class CacheTests extends QUnitTestCaseBase {
 			);
 			
 		$this->assertTrue(is_array($arrPeople->_ProjectAsManagerArray), "_ProjectAsManagerArray is an array");
-		$this->assertEquals(count($arrPeople->_ProjectAsManagerArray), 0, "_ProjectAsManagerArray has no Project objects");
+		$this->assertEquals(0, count($arrPeople->_ProjectAsManagerArray), "_ProjectAsManagerArray has no Project objects");
 	}
 
 	public function testNullArray() {
@@ -187,10 +187,11 @@ class CacheTests extends QUnitTestCaseBase {
 			);
 		
 		$intPersonTypeArray = $objPerson->_PersonTypeArray;
-		$this->assertEquals($intPersonTypeArray, array(
+		$this->assertEquals(array(
 			PersonType::Manager,
 			PersonType::CompanyCar)
-		, "PersonType expansion is correct");
+			, $intPersonTypeArray
+			, "PersonType expansion is correct");
 	}
 
 	private static function getTestClauses() {
@@ -202,10 +203,10 @@ class CacheTests extends QUnitTestCaseBase {
 	}
 	
 	private function helperVerifyKarenWolfe(Person $targetPerson) {		
-		$this->assertEquals(sizeof($targetPerson->_ProjectAsManagerArray), 2, "2 projects found");
+		$this->assertEquals(2, sizeof($targetPerson->_ProjectAsManagerArray), "2 projects found");
 		$targetProject = $this->verifyObjectPropertyHelper($targetPerson->_ProjectAsManagerArray, 'Name', 'ACME Payment System');
 		
-		$this->assertEquals(sizeof($targetProject->_MilestoneArray), 4, "4 milestones found");
+		$this->assertEquals(4, sizeof($targetProject->_MilestoneArray), "4 milestones found");
 		$this->verifyObjectPropertyHelper($targetProject->_MilestoneArray, 'Name', 'Milestone H');
 	}
 
@@ -282,10 +283,10 @@ class CacheTests extends QUnitTestCaseBase {
 		$objPeopleArray = $objMilestone->Project->_PersonAsTeamMemberArray;
 		
 		$this->assertTrue(is_array($objProjectArray), "_ProjectAsTeamMemberArray is an array");
-		$this->assertEquals(count($objProjectArray), 2, "_ProjectAsTeamMemberArray has 2 Project objects");
+		$this->assertEquals(2, count($objProjectArray), "_ProjectAsTeamMemberArray has 2 Project objects");
 		
 		$this->assertTrue(is_array($objPeopleArray), "_PersonAsTeamMemberArray is an array");
-		$this->assertEquals(count($objPeopleArray), 5, "_PersonAsTeamMemberArray has 5 People objects");
+		$this->assertEquals(5, count($objPeopleArray), "_PersonAsTeamMemberArray has 5 People objects");
 		
 		// try through a unique relationship
 		$objLogin = Login::QuerySingle(
@@ -299,12 +300,12 @@ class CacheTests extends QUnitTestCaseBase {
 		$objProjectArray = $objLogin->Person->_ProjectAsTeamMemberArray;
 		
 		$this->assertTrue(is_array($objProjectArray), "_ProjectAsTeamMemberArray is an array");
-		$this->assertEquals(count($objProjectArray), 2, "_ProjectAsTeamMemberArray has 2 Project objects");
+		$this->assertEquals(2, count($objProjectArray), "_ProjectAsTeamMemberArray has 2 Project objects");
 		
 		$objProjectArray = $objLogin->Person->_ProjectAsManagerArray;
 		
 		$this->assertTrue(is_array($objProjectArray), "_ProjectAsManagerArray is an array");
-		$this->assertEquals(count($objProjectArray), 2, "_ProjectAsManagerArray has 2 Project objects");
+		$this->assertEquals(2, count($objProjectArray), "_ProjectAsManagerArray has 2 Project objects");
 				
 	}
 
@@ -335,4 +336,3 @@ class CacheTests extends QUnitTestCaseBase {
 	}
 
 }
-?>

--- a/includes/tests/qcubed-unit/ExpandAsArrayTest.php
+++ b/includes/tests/qcubed-unit/ExpandAsArrayTest.php
@@ -41,24 +41,24 @@ class ExpandAsArrayTests extends QUnitTestCaseBase {
 			self::getTestClauses()
 		);
 				
-		$this->assertEquals(sizeof($arrPeople), 12, "12 Person objects found");
+		$this->assertEquals(12, sizeof($arrPeople), "12 Person objects found");
 		$targetPerson = $this->verifyObjectPropertyHelper($arrPeople, 'LastName', 'Wolfe');
 		
 		$this->helperVerifyKarenWolfe($targetPerson);
 		
 		$objProjectArray = $targetPerson->_ProjectAsManagerArray;
-		$this->assertEquals(sizeof($objProjectArray), 2, "2 projects found");
+		$this->assertEquals(2, sizeof($objProjectArray), "2 projects found");
 		
 		foreach ($objProjectArray as $objProject) {
 			$objMilestoneArray = $objProject->_MilestoneArray;
 			
 			switch ($objProject->Id) {
 				case 1:
-					$this->assertEquals(sizeof($objMilestoneArray), 3, "3 milestones found");
+					$this->assertEquals(3, sizeof($objMilestoneArray), "3 milestones found");
 					break;
 					
 				case 4:
-					$this->assertEquals(sizeof($objMilestoneArray), 4, "4 milestones found");
+					$this->assertEquals(4, sizeof($objMilestoneArray), "4 milestones found");
 					break;
 					
 				default:
@@ -79,7 +79,7 @@ class ExpandAsArrayTests extends QUnitTestCaseBase {
 		);
 
 		// Karen Wolfe should duplicate, since she is managing two projects
-		$this->assertEquals(sizeof($arrPeople), 13, "13 Person objects found");
+		$this->assertEquals(13, sizeof($arrPeople), "13 Person objects found");
 		$targetPerson = $this->verifyObjectPropertyHelper($arrPeople, 'LastName', 'Wolfe');
 
 		$objProjectArray = $targetPerson->_ProjectAsManagerArray;
@@ -92,11 +92,11 @@ class ExpandAsArrayTests extends QUnitTestCaseBase {
 		// since we didn't specify the order, not sure which one we will get, so check for either
 		switch ($objProject->Id) {
 			case 1:
-				$this->assertEquals(sizeof($objMilestoneArray), 3, "3 milestones found");
+				$this->assertEquals(3, sizeof($objMilestoneArray), "3 milestones found");
 				break;
 				
 			case 4:
-				$this->assertEquals(sizeof($objMilestoneArray), 4, "4 milestones found");
+				$this->assertEquals(4, sizeof($objMilestoneArray), "4 milestones found");
 				break;
 				
 			default:
@@ -133,7 +133,7 @@ class ExpandAsArrayTests extends QUnitTestCaseBase {
 			);
 			
 		$this->assertTrue(is_array($arrPeople->_ProjectAsManagerArray), "_ProjectAsManagerArray is an array");
-		$this->assertEquals(count($arrPeople->_ProjectAsManagerArray), 0, "_ProjectAsManagerArray has no Project objects");
+		$this->assertEquals(0, count($arrPeople->_ProjectAsManagerArray), "_ProjectAsManagerArray has no Project objects");
 	}
 
 	public function testNullArray() {
@@ -156,10 +156,11 @@ class ExpandAsArrayTests extends QUnitTestCaseBase {
 			);
 		
 		$intPersonTypeArray = $objPerson->_PersonTypeArray;
-		$this->assertEquals($intPersonTypeArray, array(
+		$this->assertEquals(array(
 			PersonType::Manager,
 			PersonType::CompanyCar)
-		, "PersonType expansion is correct");
+			, $intPersonTypeArray
+			, "PersonType expansion is correct");
 	}
 
 	private static function getTestClauses() {
@@ -171,10 +172,10 @@ class ExpandAsArrayTests extends QUnitTestCaseBase {
 	}
 	
 	private function helperVerifyKarenWolfe(Person $targetPerson) {		
-		$this->assertEquals(sizeof($targetPerson->_ProjectAsManagerArray), 2, "2 projects found");
+		$this->assertEquals(2, sizeof($targetPerson->_ProjectAsManagerArray), "2 projects found");
 		$targetProject = $this->verifyObjectPropertyHelper($targetPerson->_ProjectAsManagerArray, 'Name', 'ACME Payment System');
 		
-		$this->assertEquals(sizeof($targetProject->_MilestoneArray), 4, "4 milestones found");
+		$this->assertEquals(4, sizeof($targetProject->_MilestoneArray), "4 milestones found");
 		$this->verifyObjectPropertyHelper($targetProject->_MilestoneArray, 'Name', 'Milestone H');
 	}
 
@@ -247,10 +248,10 @@ class ExpandAsArrayTests extends QUnitTestCaseBase {
 		$objPeopleArray = $objMilestone->Project->_PersonAsTeamMemberArray;
 		
 		$this->assertTrue(is_array($objProjectArray), "_ProjectAsTeamMemberArray is an array");
-		$this->assertEquals(count($objProjectArray), 2, "_ProjectAsTeamMemberArray has 2 Project objects");
+		$this->assertEquals(2, count($objProjectArray), "_ProjectAsTeamMemberArray has 2 Project objects");
 		
 		$this->assertTrue(is_array($objPeopleArray), "_PersonAsTeamMemberArray is an array");
-		$this->assertEquals(count($objPeopleArray), 5, "_PersonAsTeamMemberArray has 5 People objects");
+		$this->assertEquals(5, count($objPeopleArray), "_PersonAsTeamMemberArray has 5 People objects");
 		
 		// try through a unique relationship
 		$objLogin = Login::QuerySingle(
@@ -264,12 +265,12 @@ class ExpandAsArrayTests extends QUnitTestCaseBase {
 		$objProjectArray = $objLogin->Person->_ProjectAsTeamMemberArray;
 		
 		$this->assertTrue(is_array($objProjectArray), "_ProjectAsTeamMemberArray is an array");
-		$this->assertEquals(count($objProjectArray), 2, "_ProjectAsTeamMemberArray has 2 Project objects");
+		$this->assertEquals(2, count($objProjectArray), "_ProjectAsTeamMemberArray has 2 Project objects");
 		
 		$objProjectArray = $objLogin->Person->_ProjectAsManagerArray;
 		
 		$this->assertTrue(is_array($objProjectArray), "_ProjectAsManagerArray is an array");
-		$this->assertEquals(count($objProjectArray), 2, "_ProjectAsManagerArray has 2 Project objects");
+		$this->assertEquals(2, count($objProjectArray), "_ProjectAsManagerArray has 2 Project objects");
 				
 	}
 
@@ -343,8 +344,8 @@ class ExpandAsArrayTests extends QUnitTestCaseBase {
 
 		$targetPerson = reset($targetPersonArray);
 
-		$this->assertEquals($targetPerson->ProjectAsTeamMember->ProjectStatusTypeId, ProjectStatusType::Completed, "Found completed parent project");
-		$this->assertEquals($targetPerson->ProjectAsTeamMember->ProjectAsRelated->ProjectStatusTypeId, ProjectStatusType::Open, "Found open child project");
+		$this->assertEquals(ProjectStatusType::Completed, $targetPerson->ProjectAsTeamMember->ProjectStatusTypeId, "Found completed parent project");
+		$this->assertEquals(ProjectStatusType::Open, $targetPerson->ProjectAsTeamMember->ProjectAsRelated->ProjectStatusTypeId, "Found open child project");
 
 	}
 
@@ -358,7 +359,7 @@ class ExpandAsArrayTests extends QUnitTestCaseBase {
 			]
 		);
 
-		$this->assertEquals($a[0]->_ProjectAsManagerArray[0]->Id, 3);
+		$this->assertEquals(3, $a[0]->_ProjectAsManagerArray[0]->Id);
 	}
 
 	public function testConditionalExpansionAssociation() {
@@ -374,7 +375,7 @@ class ExpandAsArrayTests extends QUnitTestCaseBase {
 			]
 		);
 
-		$this->assertEquals($a[2]->_ParentProjectAsRelatedArray[0]->Id, 1);
+		$this->assertEquals(1, $a[2]->_ParentProjectAsRelatedArray[0]->Id);
 	}
 
 
@@ -396,4 +397,3 @@ class ExpandAsArrayTests extends QUnitTestCaseBase {
 	}
 	
 }
-?>

--- a/includes/tests/qcubed-unit/ModelConnectorTest.php
+++ b/includes/tests/qcubed-unit/ModelConnectorTest.php
@@ -40,11 +40,11 @@ class ModelConnectorTests extends QUnitTestCaseBase {
 		$this->assertTrue ($dt->IsEqualTo (new QDateTime ('10/10/2010', null, QDateTime::DateOnlyType)), 'Date only type saved correctly through connector.');
 		$dt = $mctTypeTest2->DateTimeControl->DateTime;
 		$this->assertTrue ($dt->IsEqualTo (new QDateTime ('11/11/2011')), 'Date time type saved correctly through connector.');
-		$this->assertEquals($mctTypeTest2->TestIntControl->Value, 5, 'Integer control saved correctly.');
-		$this->assertEquals($mctTypeTest2->TestFloatControl->Value, 3.5, 'Float type saved correctly.');
-		$this->assertEquals($mctTypeTest2->TestVarcharControl->Text, 'abcde', 'Varchar control type saved correctly through connector.');
-		$this->assertEquals($mctTypeTest2->TestTextControl->Text, 'ABCDE', 'Text type saved correctly through connector.');
-		$this->assertEquals($mctTypeTest2->TestBitControl->Checked, true, 'Bit saved correctly through connector.');
+		$this->assertEquals(5, $mctTypeTest2->TestIntControl->Value, 'Integer control saved correctly.');
+		$this->assertEquals(3.5, $mctTypeTest2->TestFloatControl->Value, 'Float type saved correctly.');
+		$this->assertEquals('abcde', $mctTypeTest2->TestVarcharControl->Text, 'Varchar control type saved correctly through connector.');
+		$this->assertEquals('ABCDE', $mctTypeTest2->TestTextControl->Text, 'Text type saved correctly through connector.');
+		$this->assertEquals(true, $mctTypeTest2->TestBitControl->Checked, 'Bit saved correctly through connector.');
 
 		$mctTypeTest2->DeleteTypeTest();
 	}
@@ -60,13 +60,13 @@ class ModelConnectorTests extends QUnitTestCaseBase {
 
 		$mctProject2 = ProjectConnector::Create (self::$frmTest, 1);
 		$objPerson = $mctProject2->Project->ManagerPerson;
-		$this->assertEquals($objPerson->Id, 6, "Forward reference saved correctly through connector.");
+		$this->assertEquals(6, $objPerson->Id, "Forward reference saved correctly through connector.");
 		$mctProject2->Project->ManagerPersonId = 7;
 		$mctProject2->Project->Save();	// restore value
 
 		// test refresh
 		$mctProject->Load (2);
-		$this->assertEquals($mctProject->ManagerPersonIdControl->SelectedValue, 4, "Reloaded forward reference connector");
+		$this->assertEquals(4, $mctProject->ManagerPersonIdControl->SelectedValue, "Reloaded forward reference connector");
 
 
 		// test through auto complete
@@ -80,12 +80,12 @@ class ModelConnectorTests extends QUnitTestCaseBase {
 
 		$mctAddress2 = AddressConnector::Create (self::$frmTest, $id);
 		$objPerson = $mctAddress2->Address->Person;
-		$this->assertEquals($objPerson->FirstName, 'Kendall', "Forward reference saved correctly through connector.");
+		$this->assertEquals('Kendall', $objPerson->FirstName, "Forward reference saved correctly through connector.");
 		$mctAddress->DeleteAddress();
 
 		// test refresh
 		$mctAddress->Load (3);
-		$this->assertEquals($mctAddress->CityControl->Text, 'New York');
+		$this->assertEquals('New York', $mctAddress->CityControl->Text);
 	}
 
 	public function testReverseReference() {
@@ -133,13 +133,13 @@ class ModelConnectorTests extends QUnitTestCaseBase {
 		$lstControl->SelectedValues = [2,4];
 		$mctPerson->SavePerson();
 		$a = Project::LoadArrayByPersonAsTeamMember(3);
-		$this->assertEquals($a[0]->Id, 2);
-		$this->assertEquals($a[1]->Id, 4);
+		$this->assertEquals(2, $a[0]->Id);
+		$this->assertEquals(4, $a[1]->Id);
 
 		$lstControl->SelectedValues = [4];
 		$mctPerson->SavePerson();
 		$a = Project::LoadArrayByPersonAsTeamMember(3);
-		$this->assertEquals($a[0]->Id, 4);
+		$this->assertEquals(4, $a[0]->Id);
 
 	}
 
@@ -149,12 +149,12 @@ class ModelConnectorTests extends QUnitTestCaseBase {
 
 		$mctProject->ProjectStatusTypeIdControl->SelectedValue = ProjectStatusType::Cancelled;
 		$mctProject->SaveProject();
-		$this->assertEquals($mctProject->Project->ProjectStatusTypeId, ProjectStatusType::Cancelled);
+		$this->assertEquals(ProjectStatusType::Cancelled, $mctProject->Project->ProjectStatusTypeId);
 
 		// restore
 		$mctProject->ProjectStatusTypeIdControl->SelectedValue = ProjectStatusType::Open;
 		$mctProject->SaveProject();
-		$this->assertEquals($mctProject->Project->ProjectStatusTypeId, ProjectStatusType::Open);
+		$this->assertEquals(ProjectStatusType::Open, $mctProject->Project->ProjectStatusTypeId);
 
 		$mctProject->Load (1);
 		$this->assertEquals ($mctProject->ProjectStatusTypeIdControl->SelectedValue, 3);
@@ -164,7 +164,7 @@ class ModelConnectorTests extends QUnitTestCaseBase {
 	public function testTypeMulti() {
 		$mctPerson = PersonConnector::Create (self::$frmTest, 3);
 		$values = $mctPerson->PersonTypeControl->SelectedValues;
-		$this->assertEquals(count ($values), 3);
+		$this->assertEquals(3, count ($values));
 
 		$values2 = $values;
 		$values2[] = 5;
@@ -172,11 +172,11 @@ class ModelConnectorTests extends QUnitTestCaseBase {
 		$mctPerson->PersonTypeControl->SelectedValues = $values2;
 		$mctPerson->SavePerson();
 		$values3 = $mctPerson->Person->GetPersonTypeArray();
-		$this->assertEquals(count ($values3), 4);
+		$this->assertEquals(4, count ($values3));
 		$mctPerson->PersonTypeControl->SelectedValues = $values;
 		$mctPerson->SavePerson();
 		$values3 = $mctPerson->Person->GetPersonTypeArray();
-		$this->assertEquals(count ($values3), 3);
+		$this->assertEquals(3, count ($values3));
 	}
 
 	/**
@@ -195,12 +195,12 @@ class ModelConnectorTests extends QUnitTestCaseBase {
 		}
 		$this->assertTrue($blnError, 'Street Label was removed by override.');
 
-		$this->assertEquals($mctAddress->CityControl->Width, '100px');
+		$this->assertEquals('100px', $mctAddress->CityControl->Width);
 
 		// Many-to-Many settings
 		$mctProject = ProjectConnector::Create (self::$frmTest);
-		$this->assertEquals($mctProject->PersonAsTeamMemberControl->RepeatColumns, 3);
-		$this->assertEquals($mctProject->PersonAsTeamMemberControl->Name, 'Team Members');
+		$this->assertEquals(3, $mctProject->PersonAsTeamMemberControl->RepeatColumns);
+		$this->assertEquals('Team Members', $mctProject->PersonAsTeamMemberControl->Name);
 
 		// Unique Reverse Reference
 		$mctPerson = PersonConnector::Create (self::$frmTest);

--- a/includes/tests/qcubed-unit/QCssTest.php
+++ b/includes/tests/qcubed-unit/QCssTest.php
@@ -14,7 +14,7 @@ class QCssTests extends QUnitTestCaseBase {
 			$objTestDataArray["Msg"] .
 			" Expected: '" . $objTestDataArray["Expected"] . "'" .
 			" Obtained: '" . $strAttrs . "'";
-		$this->assertEquals($strAttrs,  $objTestDataArray["Expected"], $strMessage);
+		$this->assertEquals($objTestDataArray["Expected"], $strAttrs, $strMessage);
 	}
 
 	public function testFormatLength() {
@@ -103,8 +103,8 @@ class QCssTests extends QUnitTestCaseBase {
 		$newValue = $objTestDataArray["NewValue"];
 		$blnChanged = QHtml::SetLength($strOldValue, $newValue);
 
-		$this->assertEquals($blnChanged,  $objTestDataArray["Changed"]);
-		$this->assertEquals($strOldValue,  $objTestDataArray["Expected"]);
+		$this->assertEquals($objTestDataArray["Changed"], $blnChanged);
+		$this->assertEquals($objTestDataArray["Expected"], $strOldValue);
 		// problem with sending a percent sign into message, so we just use default message.
 	}
 
@@ -149,8 +149,8 @@ class QCssTests extends QUnitTestCaseBase {
 		$newValue = $objTestDataArray["NewValue"];
 		$blnChanged = QHtml::AddClass($strOldValue, $newValue);
 
-		$this->assertEquals($blnChanged,  $objTestDataArray["Changed"]);
-		$this->assertEquals($strOldValue,  $objTestDataArray["Expected"]);
+		$this->assertEquals($objTestDataArray["Changed"], $blnChanged);
+		$this->assertEquals($objTestDataArray["Expected"], $strOldValue);
 		// problem with sending a percent sign into message, so we just use default message.
 	}
 
@@ -183,8 +183,8 @@ class QCssTests extends QUnitTestCaseBase {
 		$newValue = $objTestDataArray["NewValue"];
 		$blnChanged = QHtml::RemoveClass($strOldValue, $newValue);
 
-		$this->assertEquals($blnChanged,  $objTestDataArray["Changed"]);
-		$this->assertEquals($strOldValue,  $objTestDataArray["Expected"]);
+		$this->assertEquals($objTestDataArray["Changed"], $blnChanged);
+		$this->assertEquals($objTestDataArray["Expected"], $strOldValue);
 		// problem with sending a percent sign into message, so we just use default message.
 	}
 
@@ -230,7 +230,7 @@ class QCssTests extends QUnitTestCaseBase {
 
 		foreach($objCaseArray as $objCase) {
 			$newValue = JavaScriptHelper::dataNameFromCamelCase($objCase["Value"]);
-			$this->assertEquals($newValue,  $objCase["Expected"]);
+			$this->assertEquals($objCase["Expected"], $newValue);
 		}
 
 		$objCaseArray = array(
@@ -250,7 +250,7 @@ class QCssTests extends QUnitTestCaseBase {
 
 		foreach($objCaseArray as $objCase) {
 			$newValue = JavaScriptHelper::dataNameToCamelCase($objCase["Value"]);
-			$this->assertEquals($newValue,  $objCase["Expected"]);
+			$this->assertEquals($objCase["Expected"], $newValue);
 		}
 
 	}

--- a/includes/tests/qcubed-unit/QDatabaseTest.php
+++ b/includes/tests/qcubed-unit/QDatabaseTest.php
@@ -78,7 +78,7 @@ class QDatabaseTests extends QUnitTestCaseBase {
 			Person::GetDatabase()->TransactionRollBack();
 			// temporary cache is throwed out. the empty application cache is restored.
 		}
-		$this->assertEquals(count(QApplication::$objCacheProvider->arrLocalCache), 0, "Object is not placed in a cache because of the transaction roll back.");
+		$this->assertEquals(0, count(QApplication::$objCacheProvider->arrLocalCache), "Object is not placed in a cache because of the transaction roll back.");
 
 		// restore the actual cache object
 		QApplication::$objCacheProvider = $objCacheProvider;
@@ -116,9 +116,9 @@ class QDatabaseTests extends QUnitTestCaseBase {
 			Person::GetDatabase()->TransactionRollBack();
 			// temporary cache is throwed out. the empty application cache is restored.
 		}
-		$this->assertEquals(count(QApplication::$objCacheProvider->arrLocalCache), 1, "Object is not dropped from a cache because of the transaction roll back.");
+		$this->assertEquals(1, count(QApplication::$objCacheProvider->arrLocalCache), "Object is not dropped from a cache because of the transaction roll back.");
 		foreach (QApplication::$objCacheProvider->arrLocalCache as $objPerson) {
-			$this->assertEquals($objPerson->FirstName, $strPerson1_FirstName, "Object is not modified in a cache because of the transaction roll back.");
+			$this->assertEquals($strPerson1_FirstName, $objPerson->FirstName, "Object is not modified in a cache because of the transaction roll back.");
 		}
 
 		// restore the actual cache object
@@ -148,16 +148,16 @@ class QDatabaseTests extends QUnitTestCaseBase {
 			Person::GetDatabase()->TransactionRollBack();
 		}
 		
-		$this->assertEquals(count(QApplication::$objCacheProvider->arrLocalCache), 0, "Object is not placed in a cache after save because of the transaction commit.");
+		$this->assertEquals(0, count(QApplication::$objCacheProvider->arrLocalCache), "Object is not placed in a cache after save because of the transaction commit.");
 		
 		// imitate the load made by other client.
 		// It populates the cache with new value.
 		$objPerson1a = Person::Load(1);
 		// new person value is placed in the application cache
 		
-		$this->assertEquals(count(QApplication::$objCacheProvider->arrLocalCache), 1, "Object is added to a cache because of the transaction commit.");
+		$this->assertEquals(1, count(QApplication::$objCacheProvider->arrLocalCache), "Object is added to a cache because of the transaction commit.");
 		foreach (QApplication::$objCacheProvider->arrLocalCache as $objPerson) {
-			$this->assertEquals($objPerson->FirstName, "New value 1", "Object is modified in a cache because of the transaction commit.");
+			$this->assertEquals("New value 1", $objPerson->FirstName, "Object is modified in a cache because of the transaction commit.");
 		}
 		
 		// Restore the original value to not break other tests
@@ -194,16 +194,16 @@ class QDatabaseTests extends QUnitTestCaseBase {
 			Person::GetDatabase()->TransactionRollBack();
 		}
 		
-		$this->assertEquals(count(QApplication::$objCacheProvider->arrLocalCache), 0, "Object is dropped from a cache because of the transaction commit.");
+		$this->assertEquals(0, count(QApplication::$objCacheProvider->arrLocalCache), "Object is dropped from a cache because of the transaction commit.");
 		
 		// imitate the load made by other client.
 		// It populates the cache with new value.
 		$objPerson1a = Person::Load(1);
 		// new person value is placed in the application cache
 		
-		$this->assertEquals(count(QApplication::$objCacheProvider->arrLocalCache), 1, "Object is not dropped from a cache because of the transaction commit.");
+		$this->assertEquals(1, count(QApplication::$objCacheProvider->arrLocalCache), "Object is not dropped from a cache because of the transaction commit.");
 		foreach (QApplication::$objCacheProvider->arrLocalCache as $objPerson) {
-			$this->assertEquals($objPerson->FirstName, "New value 1", "Object is modified in a cache because of the transaction commit.");
+			$this->assertEquals("New value 1", $objPerson->FirstName, "Object is modified in a cache because of the transaction commit.");
 		}
 		
 		// Restore the original value to not break other tests
@@ -242,7 +242,7 @@ class QDatabaseTests extends QUnitTestCaseBase {
 			Person::GetDatabase()->TransactionRollBack();
 		}
 		
-		$this->assertEquals(count(QApplication::$objCacheProvider->arrLocalCache), 0, "Object is not placed in a cache after delete because of the transaction commit.");
+		$this->assertEquals(0, count(QApplication::$objCacheProvider->arrLocalCache), "Object is not placed in a cache after delete because of the transaction commit.");
 		
 		// restore the actual cache object
 		QApplication::$objCacheProvider = $objCacheProvider;
@@ -264,7 +264,7 @@ class QDatabaseTests extends QUnitTestCaseBase {
 		
 		Person::Load($objPerson1z->Id);
 		// the person object is placed in a cache
-		$this->assertEquals(count(QApplication::$objCacheProvider->arrLocalCache), 1, "Object is placed in a cache.");
+		$this->assertEquals(1, count(QApplication::$objCacheProvider->arrLocalCache), "Object is placed in a cache.");
 		
 		try {
 			Person::GetDatabase()->TransactionBegin();
@@ -280,7 +280,7 @@ class QDatabaseTests extends QUnitTestCaseBase {
 			Person::GetDatabase()->TransactionRollBack();
 		}
 		
-		$this->assertEquals(count(QApplication::$objCacheProvider->arrLocalCache), 0, "Object is removed from a cache after delete because of the transaction commit.");
+		$this->assertEquals(0, count(QApplication::$objCacheProvider->arrLocalCache), "Object is removed from a cache after delete because of the transaction commit.");
 		
 		// restore the actual cache object
 		QApplication::$objCacheProvider = $objCacheProvider;
@@ -316,7 +316,7 @@ class QDatabaseTests extends QUnitTestCaseBase {
 			// actual cache leaved unchanged
 		}
 		
-		$this->assertEquals(count(QApplication::$objCacheProvider->arrLocalCache), 0, "Object is not placed in a cache after delete because of the transaction roll back.");
+		$this->assertEquals(0, count(QApplication::$objCacheProvider->arrLocalCache), "Object is not placed in a cache after delete because of the transaction roll back.");
 		
 		// restore the actual cache object
 		QApplication::$objCacheProvider = $objCacheProvider;
@@ -343,7 +343,7 @@ class QDatabaseTests extends QUnitTestCaseBase {
 		
 		Person::Load($objPerson1z->Id);
 		// the person object is placed in a cache
-		$this->assertEquals(count(QApplication::$objCacheProvider->arrLocalCache), 1, "Object is placed in a cache.");
+		$this->assertEquals(1, count(QApplication::$objCacheProvider->arrLocalCache), "Object is placed in a cache.");
 		
 		try {
 			Person::GetDatabase()->TransactionBegin();
@@ -361,7 +361,7 @@ class QDatabaseTests extends QUnitTestCaseBase {
 			// actual cache leaved unchanged
 		}
 		
-		$this->assertEquals(count(QApplication::$objCacheProvider->arrLocalCache), 1, "Object is NOT removed from a cache after delete because of the transaction roll back.");
+		$this->assertEquals(1, count(QApplication::$objCacheProvider->arrLocalCache), "Object is NOT removed from a cache after delete because of the transaction roll back.");
 		
 		// restore the actual cache object
 		QApplication::$objCacheProvider = $objCacheProvider;

--- a/includes/tests/qcubed-unit/QDateTimeTest.php
+++ b/includes/tests/qcubed-unit/QDateTimeTest.php
@@ -51,7 +51,7 @@ class QDateTimeTests extends QUnitTestCaseBase {
 		$this->assertTrue($diff->IsPositive());
 		$this->assertFalse($diff->IsNegative());
 		$this->assertFalse($diff->IsZero());
-		$this->assertEquals($diff->Minutes, 1);
+		$this->assertEquals(1, $diff->Minutes);
 
 		// being fuzzy here intentionally
 		$this->assertTrue($diff->Seconds > 95);
@@ -72,7 +72,7 @@ class QDateTimeTests extends QUnitTestCaseBase {
 
 		// test timestamp constructor
 		$dt2 = new QDateTime ('@' . $dtNow->Timestamp);
-		$this->assertEquals($dt2->Hour, $dtNow->Hour);
+		$this->assertEquals($dtNow->Hour, $dt2->Hour);
 	}
 
 
@@ -136,25 +136,25 @@ class QDateTimeTests extends QUnitTestCaseBase {
 	public function testTimeZoneIssues() {
 		$tz = new DateTimeZone('America/Los_Angeles');
 		$dt1 = new QDateTime ('11/02/14', $tz); // dst boundary date
-		$this->assertEquals($dt1->getTimezone()->getName(), 'America/Los_Angeles');
+		$this->assertEquals('America/Los_Angeles', $dt1->getTimezone()->getName());
 
 		$dt2 = new QDateTime ($dt1, null, QDateTime::DateOnlyType);
-		$this->assertEquals($dt2->getTimezone()->getName(), 'America/Los_Angeles');
+		$this->assertEquals('America/Los_Angeles', $dt2->getTimezone()->getName());
 		$this->assertTrue($dt2->IsTimeNull());
 
 		$dt2->setTime(7,0,0);
-		$this->assertEquals($dt2->Hour, 7);
-		$this->assertEquals($dt2->getTimezone()->getName(), 'America/Los_Angeles');
+		$this->assertEquals(7, $dt2->Hour);
+		$this->assertEquals('America/Los_Angeles', $dt2->getTimezone()->getName());
 
 		// Test a specific PHP 'bug'. Not sure if it is a bug, or just a way things work.
 		$dt2 = new QDateTime ($dt1->format (DateTime::ISO8601), null, QDateTime::DateOnlyType);
 		$dt2->setTime(7,0,0);
-		$this->assertEquals($dt2->Hour, 7);
+		$this->assertEquals(7, $dt2->Hour);
 
 		$dt2 = new QDateTime('1/1/14', new DateTimeZone('America/Los_Angeles'));
 		$dt2->Timestamp = 1288486753;
-		$this->assertEquals($dt2->getTimezone()->getName(), 'America/Los_Angeles'); // make sure timezone isn't changed
-		$this->assertEquals($dt2->Timestamp, 1288486753); // this isn't always true. If this is a dst boundary, it will not be true. Just making sure it is true when its supposed to be
+		$this->assertEquals('America/Los_Angeles', $dt2->getTimezone()->getName()); // make sure timezone isn't changed
+		$this->assertEquals(1288486753, $dt2->Timestamp); // this isn't always true. If this is a dst boundary, it will not be true. Just making sure it is true when its supposed to be
 
 	}
 
@@ -165,7 +165,7 @@ class QDateTimeTests extends QUnitTestCaseBase {
 		$dt2 = new QDateTime ('7:00', $tz, QDateTime::TimeOnlyType);
 
 		$dt1->SetTime ($dt2);
-		$this->assertEquals($dt2->Hour, 7);
+		$this->assertEquals(7, $dt2->Hour);
 	}
 */
 
@@ -179,7 +179,7 @@ class QDateTimeTests extends QUnitTestCaseBase {
 
 		$diff = $obj2->Difference($obj1);
 		$this->assertTrue($diff->IsPositive());
-		$this->assertEquals($diff->Months, 15);
+		$this->assertEquals(15, $diff->Months);
 	}
 
 	public function testOperations2() {
@@ -191,7 +191,7 @@ class QDateTimeTests extends QUnitTestCaseBase {
 
 		$diff = $obj2->Difference($obj1);
 		$this->assertTrue($diff->IsNegative());
-		$this->assertEquals($diff->Years, -1);
+		$this->assertEquals(-1, $diff->Years);
 	}
 
 	public function testRoundtrip() {
@@ -230,9 +230,9 @@ class QDateTimeTests extends QUnitTestCaseBase {
 	public function testFormat() {
 		$obj1 = new QDateTime("2002-3-5 13:15");
 
-		$this->assertEquals($obj1->qFormat("M/D/YY h:mm z"), "3/5/02 1:15 pm");
-		$this->assertEquals($obj1->qFormat("DDD MMM D YYYY"), "Tue Mar 5 2002");
-		$this->assertEquals($obj1->qFormat("One random DDDD in MMMM"), "One random Tuesday in March");
+		$this->assertEquals("3/5/02 1:15 pm", $obj1->qFormat("M/D/YY h:mm z"));
+		$this->assertEquals("Tue Mar 5 2002", $obj1->qFormat("DDD MMM D YYYY"));
+		$this->assertEquals("One random Tuesday in March", $obj1->qFormat("One random DDDD in MMMM"));
 
 		//  Back compat
 		$this->assertEquals($obj1->qFormat("M/D/YY h:mm z"), $obj1->qFormat("M/D/YY h:mm z"));
@@ -240,31 +240,31 @@ class QDateTimeTests extends QUnitTestCaseBase {
 
 	public function testFirstOfMonth() {
 		$dt1 = new QDateTime("2/23/2009");
-		$this->assertEquals($dt1->FirstDayOfTheMonth, new QDateTime("2/1/2009"));
+		$this->assertEquals(new QDateTime("2/1/2009"), $dt1->FirstDayOfTheMonth);
 
 		$dt2 = new QDateTime("12/2/2015");
-		$this->assertEquals($dt2->FirstDayOfTheMonth, new QDateTime("12/1/2015"));
+		$this->assertEquals(new QDateTime("12/1/2015"), $dt2->FirstDayOfTheMonth);
 
 		// static function test
-		$this->assertEquals(QDateTime::FirstDayOfTheMonth(1,1923), new QDateTime("1/1/1923"));
+		$this->assertEquals(new QDateTime("1/1/1923"), QDateTime::FirstDayOfTheMonth(1,1923));
 	}
 
 	public function testLastOfMonth() {
 		$dt1 = new QDateTime("2/23/2009");
-		$this->assertEquals($dt1->LastDayOfTheMonth, new QDateTime("2/28/2009"));
+		$this->assertEquals(new QDateTime("2/28/2009"), $dt1->LastDayOfTheMonth);
 
 		$dt2 = new QDateTime("1/1/1923");
-		$this->assertEquals($dt2->LastDayOfTheMonth, new QDateTime("1/31/1923"));
+		$this->assertEquals(new QDateTime("1/31/1923"), $dt2->LastDayOfTheMonth);
 
 		// Leap year tests
 		$dt3 = new QDateTime("2/4/2000");
-		$this->assertEquals($dt3->LastDayOfTheMonth, new QDateTime("2/29/2000"));
+		$this->assertEquals(new QDateTime("2/29/2000"), $dt3->LastDayOfTheMonth);
 
 		$dt4 = new QDateTime("2/4/2016");
-		$this->assertEquals($dt4->LastDayOfTheMonth, new QDateTime("2/29/2016"));
+		$this->assertEquals(new QDateTime("2/29/2016"), $dt4->LastDayOfTheMonth);
 
 		// static function test
-		$this->assertEquals(QDateTime::LastDayOfTheMonth(12, 2015), new QDateTime("12/31/2015"));
+		$this->assertEquals(new QDateTime("12/31/2015"), QDateTime::LastDayOfTheMonth(12, 2015));
 	}
 
 	public function testSerialize() {

--- a/includes/tests/qcubed-unit/QI18nTest.php
+++ b/includes/tests/qcubed-unit/QI18nTest.php
@@ -47,7 +47,7 @@ class QI18nTests extends QUnitTestCaseBase {
 	}
 	
 	private function verifyTranslation($original, $translation, $expectedTranslation) {
-		$this->assertEquals($translation, $expectedTranslation, "'" . $original . "' translates to '" . $translation . "'.");
+		$this->assertEquals($expectedTranslation, $translation, "'" . $original . "' translates to '" . $translation . "'.");
 	}
   
   public function tearDown() {

--- a/includes/tests/qcubed-unit/QQAliasTest.php
+++ b/includes/tests/qcubed-unit/QQAliasTest.php
@@ -22,7 +22,7 @@ class QQAliasTests extends QUnitTestCaseBase {
 			)
 		);
 		
-		$this->assertEquals(sizeof($objPersonArray), 3);
+		$this->assertEquals(3, sizeof($objPersonArray));
 		$this->verifyObjectPropertyHelper($objPersonArray, 'FirstName', 'Kendall');
 		$this->verifyObjectPropertyHelper($objPersonArray, 'LastName', 'Wolfe');
 		$this->verifyObjectPropertyHelper($objPersonArray, 'LastName', 'Smith');
@@ -36,7 +36,7 @@ class QQAliasTests extends QUnitTestCaseBase {
 			)
 		);
 
-		$this->assertEquals(sizeof($objProjectArray), 1);
+		$this->assertEquals(1, sizeof($objProjectArray));
 		$this->verifyObjectPropertyHelper($objProjectArray, 'Name', 'ACME Website Redesign');
 
 	}	
@@ -66,18 +66,18 @@ class QQAliasTests extends QUnitTestCaseBase {
 				)
 			)
 		);
-		$this->assertEquals(sizeof($objPersonArray), 3);
+		$this->assertEquals(3, sizeof($objPersonArray));
 		$obj = $this->verifyObjectPropertyHelper($objPersonArray, 'LastName', 'Doe');
 		$this->assertNull($obj->GetVirtualAttribute('min_voyel'));
-		$this->assertEquals($obj->GetVirtualAttribute('min_conson'), 'Milestone F');
+		$this->assertEquals('Milestone F', $obj->GetVirtualAttribute('min_conson'));
 
 		$obj = $this->verifyObjectPropertyHelper($objPersonArray, 'LastName', 'Ho');
-		$this->assertEquals($obj->GetVirtualAttribute('min_voyel'), 'Milestone E');
-		$this->assertEquals($obj->GetVirtualAttribute('min_conson'), 'Milestone D');
+		$this->assertEquals('Milestone E', $obj->GetVirtualAttribute('min_voyel'));
+		$this->assertEquals('Milestone D', $obj->GetVirtualAttribute('min_conson'));
 
 		$obj = $this->verifyObjectPropertyHelper($objPersonArray, 'LastName', 'Wolfe');
-		$this->assertEquals($obj->GetVirtualAttribute('min_voyel'), 'Milestone A');
-		$this->assertEquals($obj->GetVirtualAttribute('min_conson'), 'Milestone B');
+		$this->assertEquals('Milestone A', $obj->GetVirtualAttribute('min_voyel'));
+		$this->assertEquals('Milestone B', $obj->GetVirtualAttribute('min_conson'));
 	}
 }
 ?>

--- a/includes/tests/qcubed-unit/QStringTest.php
+++ b/includes/tests/qcubed-unit/QStringTest.php
@@ -21,24 +21,24 @@ class QStringTest extends QUnitTestCaseBase {
 	}
 
 	public function testEndsWithStartsWith() {
-		$this->assertEquals(QString::StartsWith("This is a test", "This"), true);
-		$this->assertEquals(QString::StartsWith("This is a test", "this"), false);
-		$this->assertEquals(QString::StartsWith("This is a test", "Thi"), true);
-		$this->assertEquals(QString::StartsWith("This is a test", "is a"), false);
-		$this->assertEquals(QString::StartsWith("This is a test", "X"), false);
-		$this->assertEquals(QString::StartsWith("This is a test", ""), true);
+		$this->assertTrue(QString::StartsWith("This is a test", "This"));
+		$this->assertFalse(QString::StartsWith("This is a test", "this"));
+		$this->assertTrue(QString::StartsWith("This is a test", "Thi"));
+		$this->assertFalse(QString::StartsWith("This is a test", "is a"));
+		$this->assertFalse(QString::StartsWith("This is a test", "X"));
+		$this->assertTrue(QString::StartsWith("This is a test", ""));
 
-		$this->assertEquals(QString::EndsWith("This is a test", "test"), true);
-		$this->assertEquals(QString::EndsWith("This is a test", "Test"), false);
-		$this->assertEquals(QString::EndsWith("This is a test", "est"), true);
-		$this->assertEquals(QString::EndsWith("This is a test", "is a"), false);
-		$this->assertEquals(QString::EndsWith("This is a test", "X"), false);
-		$this->assertEquals(QString::EndsWith("This is a test", ""), true);
+		$this->assertTrue(QString::EndsWith("This is a test", "test"));
+		$this->assertFalse(QString::EndsWith("This is a test", "Test"));
+		$this->assertTrue(QString::EndsWith("This is a test", "est"));
+		$this->assertFalse(QString::EndsWith("This is a test", "is a"));
+		$this->assertFalse(QString::EndsWith("This is a test", "X"));
+		$this->assertTrue(QString::EndsWith("This is a test", ""));
 	}
 
 	private function lcsCheckValueHelper($str1, $str2, $strExpectedResult) {
 		$strResult = QString::LongestCommonSubsequence($str1, $str2); 
-		$this->assertEquals($strResult, $strExpectedResult, "Longest common subsequence of '" . $str1 . 
+		$this->assertEquals($strExpectedResult, $strResult, "Longest common subsequence of '" . $str1 .
 			"' and '" . $str2 . "' is '" . $strResult . "'");
 	}	
 }

--- a/includes/tests/qcubed-unit/QTimerTest.php
+++ b/includes/tests/qcubed-unit/QTimerTest.php
@@ -39,7 +39,7 @@ class QTimerTests extends QUnitTestCaseBase {
 		$this->assertTrue($fltValue2 < $fltValue3);
 		
 		$objTimer = QTimer::GetTimer('timer2');
-		$this->assertEquals($objTimer->CountStarted, 3);
+		$this->assertEquals(3, $objTimer->CountStarted);
 	}
 	
 	public function testReset() {
@@ -61,7 +61,7 @@ class QTimerTests extends QUnitTestCaseBase {
 		$this->assertTrue($fltValue4 < $fltValue3); // because we've reset the timer
 		
 		$objTimer = QTimer::GetTimer('timerA');
-		$this->assertEquals($objTimer->CountStarted, 2);
+		$this->assertEquals(2, $objTimer->CountStarted);
 	}
 	
 
@@ -84,7 +84,7 @@ class QTimerTests extends QUnitTestCaseBase {
 	
 	public function testExceptions4() {
 		$objTimer = QTimer::GetTimer('timer7');
-		$this->assertEquals($objTimer, null, "Requests for non-existing timer objects should return null");
+		$this->assertEquals(null, $objTimer, "Requests for non-existing timer objects should return null");
 	}
 
 

--- a/includes/tests/qcubed-unit/QTypeTest.php
+++ b/includes/tests/qcubed-unit/QTypeTest.php
@@ -92,16 +92,16 @@ class QTypeTests extends QUnitTestCaseBase {
 
 		$cond = QQ::Between(QQN::Project()->StartDate, $dt1, $dt2);
 		$a = Project::QueryArray($cond);
-		$this->assertEquals(count($a), 2, "Between 2 QDateTime types works");
+		$this->assertEquals(2, count($a), "Between 2 QDateTime types works");
 
 
 		$cond = QQ::Between(QQN::Project()->Budget, 2000, 3000);
 		$a = Project::QueryArray($cond);
-		$this->assertEquals(count($a), 1, "Between 2 int types works");
+		$this->assertEquals(1, count($a), "Between 2 int types works");
 
 		$cond = QQ::Between(QQN::Project()->Name, 'A', 'C');
 		$a = Project::QueryArray($cond);
-		$this->assertEquals(count($a), 3, "Between 2 string types works");
+		$this->assertEquals(3, count($a), "Between 2 string types works");
 	}
 
 	// Testing creation of type tables
@@ -111,8 +111,8 @@ class QTypeTests extends QUnitTestCaseBase {
 		$this->assertNull($val, 'Generated a null value');
 
 		$val = ProjectStatusType::$IsActiveArray[1];
-		$this->assertEquals($val, true, 'Open project is active');
-		$this->assertEquals(is_bool($val), true, 'Type of variable is boolean.');
+		$this->assertTrue($val, 'Open project is active');
+		$this->assertTrue(is_bool($val), 'Type of variable is boolean.');
 
 	}
 }

--- a/includes/tests/qcubed-unit/QUnitTestCaseBase.php
+++ b/includes/tests/qcubed-unit/QUnitTestCaseBase.php
@@ -35,4 +35,3 @@ class QUnitTestCaseBase extends \PHPUnit_Framework_TestCase {
 		return $objResult;
 	}
 }
-?>


### PR DESCRIPTION
Reversing asserEquals calls so that the expected value is first. Fixes #987.