### PR TITLE
bugfix-StyleRender

### DIFF
--- a/includes/base_controls/QSimpleTableColumn.class.php
+++ b/includes/base_controls/QSimpleTableColumn.class.php
@@ -155,13 +155,16 @@
 				$aParams['scope'] = 'row';
 			}
 
+			$strStyle = $this->GetCellStyle ($item);
+
 			if ($this->objCellStyler) {
-				$strStyle = $this->GetCellStyle ($item);
-				$aParams = $this->objCellStyler->GetHtmlAttributes($aParams, explode(';', $strStyle));
-			} else {
-				if ($strStyle = $this->GetCellStyle ($item)) {
-					$aParams['style'] = $strStyle;
+				$aStyles = null;
+				if ($strStyle) {
+					$aStyles = explode (';', $strStyle);
 				}
+				$aParams = $this->objCellStyler->GetHtmlAttributes($aParams, $aStyles);
+			} elseif ($strStyle) {
+				$aParams['style'] = $strStyle;
 			}
 
 			if ($this->cellParamsCallback) {


### PR DESCRIPTION
Fixing problem where a '0' style is inserted if there is no style. A result of "explode" returning an array even when there are no delimiters found in the string.