### PR TITLE
QSubSql generates invalid sql in some cases.

### DIFF
--- a/includes/qcubed/_core/framework/QQuery.class.php
+++ b/includes/qcubed/_core/framework/QQuery.class.php
@@ -1326,7 +1326,11 @@
 				if (!is_null($this->objParentQueryNodes[$intIndex]))
 					$strSql = str_replace('{' . $intIndex . '}', $this->objParentQueryNodes[$intIndex]->GetColumnAlias($objBuilder), $strSql);
 			}
-			return '(' . $strSql . ')';
+			if(stripos($strSql, 'SELECT')===0) {
+				return '(' . $strSql . ')';
+			} else {
+				return $strSql;
+			}
 		}
 	}
 


### PR DESCRIPTION
You only need to wrap a subsql statement with braces (  ) when it is an actual query. 
For example: 
`SELECT * FROM table1 WHERE col1 = (SELECT count(id) FROM table2)`

If you want to use QSubSql for something other that pure queries, you can run into problems.
For example: 
```
Client::QuerySingle(
          QQ::All(),
          QQ::Clause(
              QQ::Count(QQ::SubSql('DISTINCT t0.client_id'), "count_clients")
          )
    );
```
Will generate
`SELECT COUNT( (DISTINCT client_id) ) as distinct_client_count FROM client;`

but that is invalid sql, it should be
`SELECT COUNT( DISTINCT client_id ) as distinct_client_count FROM client;`
Without the braces ( )