### PR TITLE
bugfix-EmptyCheckBoxList

### DIFF
--- a/assets/js/qcubed.js
+++ b/assets/js/qcubed.js
@@ -231,7 +231,7 @@ qcubed = {
                         }
                         else {
                             if (!a) {
-                                values[id] = []; // empty array to notify that the group has a null value, if nothing gets checked
+                                values[id] = null; // empty array to notify that the group has a null value, if nothing gets checked
                             }
                         }
                     } else {

--- a/includes/base_controls/QCheckBoxList.class.php
+++ b/includes/base_controls/QCheckBoxList.class.php
@@ -69,7 +69,7 @@
 		 */
 		public function ParsePostData() {
 			$val = $this->objForm->CheckableControlValue($this->strControlId);
-			if ($val === null) {
+			if (empty($val)) {
 				$this->UnselectAllItems(false);
 			}
 			else {


### PR DESCRIPTION
Fixing problem detecting an empty checkbox list. An empty array was not being sent through to the server.