### PR TITLE
bugfix-RadioListRefresh

### DIFF
--- a/includes/base_controls/QRadioButtonList.class.php
+++ b/includes/base_controls/QRadioButtonList.class.php
@@ -74,7 +74,7 @@
 			if ($val === null) {
 				$this->UnselectAllItems(false);
 			} else {
-				$this->SelectedIndex = $val;
+				$this->SetSelectedItemsByIndex(array($val), false);
 			}
 		}
 


### PR DESCRIPTION
Fixing refresh problem. This fix prevents the radio list from refreshing again when reading a change from the browser.