### PR TITLE
bugfix-EmptyTableErrors

### DIFF
--- a/includes/base_controls/QHtmlTableBase.class.php
+++ b/includes/base_controls/QHtmlTableBase.class.php
@@ -28,7 +28,7 @@
 	 */
 	abstract class QHtmlTableBase extends QPaginatedControl {
 		/** @var QAbstractHtmlTableColumn[] */
-		protected $objColumnArray;
+		protected $objColumnArray = [];
 
 		/** @var string|null CSS class to be applied to for even rows */
 		protected $strRowCssClass = null;


### PR DESCRIPTION
Initializing columns to an empty set to prevent errors when drawing an empty table.