### PR TITLE
bugfix-BadRecordIdLoad

### DIFF
--- a/includes/codegen/templates/db_orm/model_connector/refresh_methods.tpl.php
+++ b/includes/codegen/templates/db_orm/model_connector/refresh_methods.tpl.php
@@ -62,13 +62,16 @@
 		}
 ?>
 		/**
-		 * Load this ModelConnector with a new <?= $objTable->ClassName ?> object.
+		 * Load this ModelConnector with a <?= $objTable->ClassName ?> object. Returns the object found, or null if not
+		 * successful. The primary reason for failure would be that the key given does not exist in the database. This
+		 * might happen due to a programming error, or in a multi-user environment, if the record was recently deleted.
 <?php foreach ($objTable->PrimaryKeyColumnArray as $objColumn) { ?>
 		 * @param null|<?= $objColumn->VariableType ?> $<?= $objColumn->VariableName ?>
 <?php } ?>
 
 		 * @param $objClauses
-		 * @return void
+		 * @return null|<?= $objCodeGen->ModelClassName($objTable->Name); ?>
+
 		 */
 		 public function Load(<?= implode (',', $aStrs) ?>, $objClauses = null) {
 			if (<?php
@@ -87,6 +90,9 @@ foreach ($objTable->PrimaryKeyColumnArray as $objColumn) {
 				$this->strTitleVerb = QApplication::Translate('Create');
 				$this->blnEditMode = false;
 			}
-			$this->Refresh ();
+			if ($this-><?= $objCodeGen->ModelVariableName($objTable->Name); ?>) {
+				$this->Refresh ();
+			}
+			return $this-><?= $objCodeGen->ModelVariableName($objTable->Name); ?>;
 		}
 		 

--- a/includes/codegen/templates/db_orm/panels/edit_load.tpl.php
+++ b/includes/codegen/templates/db_orm/panels/edit_load.tpl.php
@@ -8,8 +8,10 @@
 			foreach ($objTable->PrimaryKeyColumnArray as $objColumn) {
 				echo '$'. $objColumn->VariableName . ' = null, ';
 			} GO_BACK(2);?>) {
-		$this->mct<?php echo $objTable->ClassName  ?>->Load (<?php
+		if (!$this->mct<?php echo $objTable->ClassName  ?>->Load (<?php
 			foreach ($objTable->PrimaryKeyColumnArray as $objColumn) {
 				echo '$'. $objColumn->VariableName . ', ';
-			} GO_BACK(2);?>);
+			} GO_BACK(2);?>)) {
+			QApplication::DisplayAlert(QApplication::Translate('Could not load the record. Perhaps it was deleted? Try again.'));
+		}
 	}


### PR DESCRIPTION
Fixing problem with trying to load a record that does not exist in the database. This would eventually cause an assertion failure in Refresh. Loading a record that does not exist should be an expected thing to happen, as there are situations where someone could load a record that was just deleted by a different user, so we need to fail more gracefully.