### PR TITLE
bugfix-SaveState

### DIFF
--- a/includes/base_controls/QControlBase.class.php
+++ b/includes/base_controls/QControlBase.class.php
@@ -334,8 +334,11 @@
 		 * Should normally be called only by FormBase code. See GetState and PutState for the control side implementation.
 		 */
 		public function _WriteState() {
+			global $_FORM;
+
+			assert ($_FORM !== null);
 			if (defined ('__SESSION_SAVED_STATE__') && $this->blnSaveState) {
-				$formName = get_class($this->objForm);
+				$formName = get_class($_FORM);	// must use global $_FORM here instead of $this->objForm, since serialization will have nulled the objForm.
 				$_SESSION[__SESSION_SAVED_STATE__][$formName][$this->ControlId] = $this->GetState();
 			}
 		}

--- a/includes/base_controls/QFormBase.class.php
+++ b/includes/base_controls/QFormBase.class.php
@@ -531,8 +531,6 @@
 				// Trigger a triggered control's Server- or Ajax- action (e.g. PHP method) here (if applicable)
 				$objClass->TriggerActions();
 
-				// Once all the controls have been set up, remember them.
-				$objClass->SaveControlState();
 			} else {
 				// We have no form state -- Create Brand New One
 				$objClass = new $strFormClass();
@@ -616,6 +614,9 @@
 				default:
 					throw new QCallerException('FormStatus is in an unknown status');
 			}
+
+			// Once all the controls have been set up, and initialized, remember them.
+			$objClass->SaveControlState();
 
 			// Tigger Exit Event (if applicable)
 			$objClass->Form_Exit();


### PR DESCRIPTION
Fixing problem where items that are changed after state is saved, like if the data was taken from a QueryString, were not getting saved.

Scenario is this:
```
public function Form_Create() {
  $txtName = QTextBox($this);
  $txtName->SaveState = true;
  if (QApplication::QueryString('name')) {
    $txtName->Text = QApplication::QueryString('name');
  }
}
```
QueryString text in this case was not being saved, and coming back to the form did not restore it when the form did not have the query string.