### PR TITLE
Update object_delete.tpl.php

### DIFF
--- a/includes/codegen/templates/db_orm/class_gen/object_delete.tpl.php
+++ b/includes/codegen/templates/db_orm/class_gen/object_delete.tpl.php
@@ -55,7 +55,7 @@
 
 			$this->DeleteFromCache();
 			if (static::$blnWatchChanges) {
-				QWatcher::MarkTableModified ('<?= QApplication::$Database[$objTable->OwnerDbIndex]->Database ?>', '<?= $objTable->Name ?>');
+				QWatcher::MarkTableModified($this->GetDatabaseName(), '<?= $objTable->Name ?>');
 			}
 
 		}
@@ -77,7 +77,7 @@
 			static::ClearCache();
 
 			if (static::$blnWatchChanges) {
-				QWatcher::MarkTableModified ('<?= QApplication::$Database[$objTable->OwnerDbIndex]->Database ?>', '<?= $objTable->Name ?>');
+				QWatcher::MarkTableModified($this->GetDatabaseName(), '<?= $objTable->Name ?>');
 			}
 		}
 

--- a/includes/codegen/templates/db_orm/class_gen/object_delete.tpl.php
+++ b/includes/codegen/templates/db_orm/class_gen/object_delete.tpl.php
@@ -55,7 +55,7 @@
 
 			$this->DeleteFromCache();
 			if (static::$blnWatchChanges) {
-				QWatcher::MarkTableModified($this->GetDatabaseName(), '<?= $objTable->Name ?>');
+				QWatcher::MarkTableModified (static::GetDatabase()->Database, '<?= $objTable->Name ?>');
 			}
 
 		}
@@ -77,7 +77,7 @@
 			static::ClearCache();
 
 			if (static::$blnWatchChanges) {
-				QWatcher::MarkTableModified($this->GetDatabaseName(), '<?= $objTable->Name ?>');
+				QWatcher::MarkTableModified (static::GetDatabase()->Database, '<?= $objTable->Name ?>');
 			}
 		}
 


### PR DESCRIPTION
Fix QWatcher::MarkTableModified call so that the database name isn't hard coded. This will stop problems when development and production databases have different names.