### PR TITLE
Update object_save.tpl.php

### DIFF
--- a/includes/codegen/templates/db_orm/class_gen/object_save.tpl.php
+++ b/includes/codegen/templates/db_orm/class_gen/object_save.tpl.php
@@ -184,7 +184,7 @@
 			$this->DeleteFromCache();
 
 			if (static::$blnWatchChanges) {
-				QWatcher::MarkTableModified ('<?= QApplication::$Database[$objTable->OwnerDbIndex]->Database ?>', '<?= $objTable->Name ?>');
+				QWatcher::MarkTableModified($this->GetDatabaseName(), '<?= $objTable->Name ?>');
 			}
 
 			// Return


### PR DESCRIPTION
Changed the way QWatcher::MarkTableModified is a called so that the database name isn't hard coded. This change will stop problems from occurring when the development environments and production environments have different database names.