### PR TITLE
Change "#" to "javascript:;" in HREF tag

### DIFF
--- a/includes/codegen/templates/db_orm/class_gen/object_delete.tpl.php
+++ b/includes/codegen/templates/db_orm/class_gen/object_delete.tpl.php
@@ -55,7 +55,7 @@
 
 			$this->DeleteFromCache();
 			if (static::$blnWatchChanges) {
-				QWatcher::MarkTableModified ('<?= QApplication::$Database[$objTable->OwnerDbIndex]->Database ?>', '<?= $objTable->Name ?>');
+				QWatcher::MarkTableModified (static::GetDatabase()->Database, '<?= $objTable->Name ?>');
 			}
 
 		}
@@ -77,7 +77,7 @@
 			static::ClearCache();
 
 			if (static::$blnWatchChanges) {
-				QWatcher::MarkTableModified ('<?= QApplication::$Database[$objTable->OwnerDbIndex]->Database ?>', '<?= $objTable->Name ?>');
+				QWatcher::MarkTableModified (static::GetDatabase()->Database, '<?= $objTable->Name ?>');
 			}
 		}
 

--- a/includes/codegen/templates/db_orm/class_gen/object_save.tpl.php
+++ b/includes/codegen/templates/db_orm/class_gen/object_save.tpl.php
@@ -184,7 +184,7 @@
 			$this->DeleteFromCache();
 
 			if (static::$blnWatchChanges) {
-				QWatcher::MarkTableModified ('<?= QApplication::$Database[$objTable->OwnerDbIndex]->Database ?>', '<?= $objTable->Name ?>');
+				QWatcher::MarkTableModified (static::GetDatabase()->Database, '<?= $objTable->Name ?>');
 			}
 
 			// Return


### PR DESCRIPTION
For the datagrid header links and the paginator controls, use "javascript:;" instead of "#" in the links so that the "#" isn't added to the querystring. The "#" can cause problems when navigating through the application.