### PR TITLE
Fixing Installation messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Older releases are available from the [downloads archive](https://github.com/qcu
 
 ## What is QCubed?
 
-QCubed (pronounced 'Q' - cubed) is a PHP5 Model-View-Controller framework. The goal of the framework is to save development time around mundane, repetitive tasks - allowing you to concentrate on things that are useful AND fun. QCubed excels in situations where you have a large database structure that you quickly want to make available to users.
+QCubed (pronounced 'Q' - cubed) is a PHP Model-View-Controller framework with support for PHP5 (5.4 and above) and PHP7. The goal of the framework is to save development time around mundane, repetitive tasks - allowing you to concentrate on things that are useful AND fun. QCubed excels in situations where you have a large database structure that you quickly want to make available to users.
 
 ## Stateful architecture
 

--- a/assets/php/_devtools/config_checker.php
+++ b/assets/php/_devtools/config_checker.php
@@ -11,7 +11,7 @@
 		require(__CONFIGURATION__ . '/header.inc.php');
 ?>
 	<h1>Welcome to QCubed!</h1>
-	<h2>PHP5 Model-View-Controller framework</h2>
+	<h2>PHP5 - PHP7 Model-View-Controller framework</h2>
 	<p>
 		This simple wizard will help you configure QCubed for first use.
 		It'll take you just a couple minutes. If you have any questions along the way, feel free to ping us on the 


### PR DESCRIPTION
Fixes #1072 for now.

Also, I strongly suggest that we put `ezyang/htmlpurifier` in the *require* section in composer.json. 

Not doing so breaks the QCrossScripting with textboxes and is not a pleasant thing, especially for a newbie. Since we are using the library in our code and it is anyways compatible (license-wise), why not install it right away? 

**Additional Note**: We have tested the PHP7 functionality in our organization with the project where we are using the framework. It is not causing any issues right now. Hence, I have added the PHP7 support in Readme and Start pages.