### PR TITLE
Fixes parsing date before 1970-01-01 00:00:00

### DIFF
--- a/includes/framework/QDateTime.class.php
+++ b/includes/framework/QDateTime.class.php
@@ -217,9 +217,15 @@
 			else {
 				// string relative date or time
 				if ($intTime = strtotime($mixValue)) {
-					parent::__construct(date('Y-m-d H:i:s', $intTime), $objTimeZone);
-					$this->blnDateNull = false;
-					$this->blnTimeNull = false;
+					if ($intTime < 0) {
+						// Set to "null date"
+						// And Do Nothing Else -- Default Values are already set to Nulled out
+						parent::__construct('2000-01-01 00:00:00', $objTimeZone);
+					} else {
+						parent::__construct(date('Y-m-d H:i:s', $intTime), $objTimeZone);
+						$this->blnDateNull = false;
+						$this->blnTimeNull = false;
+					}
 				} else { // error
 					parent::__construct();
 					$this->blnDateNull = true;

--- a/includes/framework/QDateTime.class.php
+++ b/includes/framework/QDateTime.class.php
@@ -217,7 +217,14 @@
 			else {
 				// string relative date or time
 				if ($intTime = strtotime($mixValue)) {
-					if ($intTime < 0) {
+					// The documentation states that:
+					// The valid range of a timestamp is typically from 
+					// Fri, 13 Dec 1901 20:45:54 GMT to Tue, 19 Jan 2038 03:14:07 GMT. 
+					// (These are the dates that correspond to the minimum and maximum values 
+					// for a 32-bit signed integer).
+					// 
+					// But experimentally, 0000-01-01 00:00:00 is the least date displayed correctly
+					if ($intTime < -62167241486) {
 						// Set to "null date"
 						// And Do Nothing Else -- Default Values are already set to Nulled out
 						parent::__construct('2000-01-01 00:00:00', $objTimeZone);


### PR DESCRIPTION
if date is earlier then this "zero" date, the resulting QDateTime object is invalid

My problem was that date obtained from mysql was just `0000-00-00 00:00:00` - essentially zero date. It leads to datetime displayed as `Nov 30 -0001 12:00 AM`. This patch fixes it.